### PR TITLE
Cyware CTIX 2.0.0 Further Updates - Enrichment Updates

### DIFF
--- a/cyware-ctix/info.json
+++ b/cyware-ctix/info.json
@@ -10,7 +10,7 @@
   "category": "Threat Intelligence",
   "icon_small_name": "cyware_ctix_small.png",
   "icon_large_name": "cyware_ctix_large.png",
-  "id": 148,
+  "help_online": "",
   "configuration": {
     "fields": [
       {
@@ -465,6 +465,8 @@
     {
       "title": "Create Intel via Open API",
       "operation": "create_intel_via_open_api",
+      "category": "investigation",
+      "annotation": "create_intel_via_open_api",
       "description": "Create intel with additional details such as the source and collection. You can also include details for each object, such as description, notes, custom attributes, and more.",
       "parameters": [
         {
@@ -475,7 +477,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the title of the intel within 100 characters."
+          "tooltip": "Specify the title of the intel within 100 characters.",
+          "description": "Specify the title of the intel within 100 characters."
         },
         {
           "title": "All SDOS",
@@ -485,7 +488,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass the SDO and IOC objects to add to the intel. For more information, see The All SDOs Object."
+          "tooltip": "Specify the SDO and IOC objects to add to the intel. For more information, see The All SDOs Object.",
+          "description": "Specify the SDO and IOC objects to add to the intel. For more information, see The All SDOs Object."
         },
         {
           "title": "Source",
@@ -495,7 +499,8 @@
           "visible": true,
           "editable": true,
           "value": "Miscellaneous",
-          "tooltip": "Pass the name of the source to map the intel.If the passed source name does not exists in the platform, then a new source is automatically created in the Miscellaneous source category."
+          "description": "Specify the name of the source to map the intel.If the passed source name does not exists in the platform, then a new source is automatically created in the Miscellaneous source category.",
+          "tooltip": "Specify the name of the source to map the intel.If the passed source name does not exists in the platform, then a new source is automatically created in the Miscellaneous source category."
         },
         {
           "title": "Collection",
@@ -505,7 +510,8 @@
           "visible": true,
           "editable": true,
           "value": "Free Text",
-          "tooltip": "Pass the name of the source collection to associate with the source.\nIf the passed collection name does not exists in the platform, then a new collection is automatically created."
+          "description": "Specify the name of the source collection to associate with the source.\nIf the passed collection name does not exists in the platform, then a new collection is automatically created.",
+          "tooltip": "Specify the name of the source collection to associate with the source.\nIf the passed collection name does not exists in the platform, then a new collection is automatically created."
         },
         {
           "title": "Metadata",
@@ -515,16 +521,17 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass additional information to associate with the intel."
+          "description": "Specify the additional information to associate with the intel.",
+          "tooltip": "Specify the additional information to associate with the intel."
         }
       ],
-      "open": false
+      "output_schema": {}
     },
     {
       "title": "Get Threat Data",
       "operation": "list_threat_data",
       "description": "Returns a list of threat data objects from the CTIX application. You can retrieve a maximum of 500,000 threat data objects using this API.",
-      "category": "",
+      "category": "investigation",
       "annotation": "list_threat_data",
       "parameters": [
         {
@@ -535,7 +542,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass a CQL query to filter and fetch results."
+          "description": "Specify a CQL query to filter and fetch results.",
+          "tooltip": "Specify a CQL query to filter and fetch results."
         },
         {
           "title": "Page",
@@ -545,7 +553,8 @@
           "visible": true,
           "editable": true,
           "value": 1,
-          "tooltip": "Pass the page number to filter threat data objects by page number."
+          "description": "Specify the page number to filter threat data objects by page number.",
+          "tooltip": "Specify the page number to filter threat data objects by page number."
         },
         {
           "title": "Page Size",
@@ -555,7 +564,8 @@
           "visible": true,
           "editable": true,
           "value": 1,
-          "tooltip": " Pass the number of records per page to filter the threat data objects by page size."
+          "description": " Specify the number of records per page to filter the threat data objects by page size.",
+          "tooltip": " Specify the number of records per page to filter the threat data objects by page size."
         },
         {
           "title": "Page Limit",
@@ -565,7 +575,8 @@
           "visible": true,
           "editable": true,
           "value": 10,
-          "tooltip": "Pass the number of threat data objects to be retrieved."
+          "description": "Specify the number of threat data objects to be retrieved.",
+          "tooltip": "Specify the number of threat data objects to be retrieved."
         },
         {
           "title": "Enrichment",
@@ -575,7 +586,8 @@
           "visible": true,
           "editable": true,
           "value": true,
-          "tooltip": "Pass true to retrieve the details of the last enrichment for the objects that can be enriched."
+          "description": "Selecting this parameter retrieves the details of the last enrichment for objects that can be enriched.",
+          "tooltip": "Selecting this parameter retrieves the details of the last enrichment for objects that can be enriched."
         },
         {
           "title": "Sort",
@@ -585,7 +597,8 @@
           "visible": true,
           "editable": true,
           "value": "-ctix_created",
-          "tooltip": ""
+          "description": "Specify the sort field you want to use for sorting the threat data response.",
+          "tooltip": "Specify the sort field you want to use for sorting the threat data response."
         }
       ],
       "output_schema": {
@@ -598,7 +611,7 @@
       "title": "Bulk Add Relation",
       "operation": "bulk_add_relation",
       "description": "Add a relation to multiple threat data objects.",
-      "category": "utilities",
+      "category": "investigation",
       "annotation": "bulk_add_relation",
       "parameters": [
         {
@@ -609,7 +622,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass the list of threat data object IDs to perform the bulk action. To retrieve a list of object IDs, use the List Threat Data API under the Threat Data section."
+          "description": "Specify the list of threat data object IDs to perform the bulk action. To retrieve a list of object IDs, use the List Threat Data API under the Threat Data section.",
+          "tooltip": "Specify the list of threat data object IDs to perform the bulk action. To retrieve a list of object IDs, use the List Threat Data API under the Threat Data section."
         },
         {
           "title": "Object Type",
@@ -619,7 +633,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the type of threat data objects. To get the list of supported object types, see Supported SDO Types in Threat Data > Miscellaneous."
+          "tooltip": "Specify the type of threat data objects. To get the list of supported object types, see Supported SDO Types in Threat Data > Miscellaneous.",
+          "description": "Specify the type of threat data objects. To get the list of supported object types, see Supported SDO Types in Threat Data > Miscellaneous."
         },
         {
           "title": "Data",
@@ -629,7 +644,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass the additional data to pass with the request."
+          "tooltip": "Specify the additional data to pass with the request.",
+          "description": "Specify the additional data to pass with the request."
         }
       ],
       "output_schema": {
@@ -642,7 +658,7 @@
       "title": "Bulk Deprecate/Undeprecate Objects",
       "operation": "bulk_deprecate_undeprecate_objects",
       "description": "Deprecate or undeprecate multiple threat data objects with one API request.",
-      "category": "utilities",
+      "category": "investigation",
       "annotation": "bulk_deprecate_undeprecate_objects",
       "parameters": [
         {
@@ -653,7 +669,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the list of threat data object IDs to perform the bulk action. To retrieve a list of object IDs, use the List Threat Data API under the Threat Data section."
+          "description": "Specify the list of threat data object IDs to perform the bulk action. To retrieve a list of object IDs, use the List Threat Data API under the Threat Data section.",
+          "tooltip": "Specify the list of threat data object IDs to perform the bulk action. To retrieve a list of object IDs, use the List Threat Data API under the Threat Data section."
         },
         {
           "title": "Object Type",
@@ -663,7 +680,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the type of threat data objects. To get the list of supported object types, see Supported SDO Types in Threat Data > Miscellaneous."
+          "description": "Specify the type of threat data objects. To get the list of supported object types, see Supported SDO Types in Threat Data > Miscellaneous.",
+          "tooltip": "Specify the type of threat data objects. To get the list of supported object types, see Supported SDO Types in Threat Data > Miscellaneous."
         },
         {
           "title": "Action Type",
@@ -673,7 +691,8 @@
           "visible": true,
           "editable": true,
           "value": "deprecate",
-          "tooltip": "Pass deprecate objects. Pass un_deprecate to undeprecate objects."
+          "description": "Specify deprecate objects. Pass un_deprecate to undeprecate objects.",
+          "tooltip": "Specify deprecate objects. Pass un_deprecate to undeprecate objects."
         }
       ],
       "output_schema": {
@@ -696,7 +715,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the list of threat data object IDs to perform the bulk action. To retrieve a list of object IDs, use the List Threat Data API under the Threat Data section"
+          "description": "Specify the list of threat data object IDs to perform the bulk action. To retrieve a list of object IDs, use the List Threat Data API under the Threat Data section",
+          "tooltip": "Specify the list of threat data object IDs to perform the bulk action. To retrieve a list of object IDs, use the List Threat Data API under the Threat Data section"
         },
         {
           "title": "Object Type",
@@ -706,7 +726,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the type of threat data objects. To get the list of supported object types, see Supported SDO Types in Threat Data > Miscellaneous."
+          "description": "Specify the type of threat data objects. To get the list of supported object types, see Supported SDO Types in Threat Data > Miscellaneous.",
+          "tooltip": "Specify the type of threat data objects. To get the list of supported object types, see Supported SDO Types in Threat Data > Miscellaneous."
         },
         {
           "title": "Action Type",
@@ -716,7 +737,8 @@
           "visible": true,
           "editable": true,
           "value": "false_positive",
-          "tooltip": "Pass false_positive to mark IOCs as false positives. Pass un_false_positive to unmark an IOCs as false positives."
+          "description": "Specify false_positive to mark IOCs as false positives. Pass un_false_positive to unmark an IOCs as false positives.",
+          "tooltip": "Specify false_positive to mark IOCs as false positives. Pass un_false_positive to unmark an IOCs as false positives."
         }
       ],
       "output_schema": {
@@ -738,7 +760,8 @@
           "required": true,
           "visible": true,
           "editable": true,
-          "tooltip": "Specify a comma-separated list of values to be used by IOCs to perform the lookup."
+          "tooltip": "Specify a comma-separated list of values to be used by IOCs to perform the lookup.",
+          "description": "Specify a comma-separated list of values to be used by IOCs to perform the lookup."
         },
         {
           "title": "Source",
@@ -748,7 +771,8 @@
           "visible": true,
           "editable": true,
           "value": "OpenAPI Lookup (OpenAPI)",
-          "tooltip": "Specify the source name that you want to map to the threat data objects."
+          "tooltip": "Specify the source name that you want to map to the threat data objects.",
+          "description": "Specify the source name that you want to map to the threat data objects."
         },
         {
           "title": "Collection",
@@ -758,7 +782,8 @@
           "visible": true,
           "editable": true,
           "value": "OpenAPI Lookup (OpenAPI)",
-          "tooltip": "Specify the collection name that you want to map to the threat data objects. If the passed source name does not exists in the platform, then a new source is automatically created with the suffix (OpenAPI) in the Miscellaneous source category."
+          "tooltip": "Specify the collection name that you want to map to the threat data objects. If the passed source name does not exists in the platform, then a new source is automatically created with the suffix (OpenAPI) in the Miscellaneous source category.",
+          "description": "Specify the collection name that you want to map to the threat data objects. If the passed source name does not exists in the platform, then a new source is automatically created with the suffix (OpenAPI) in the Miscellaneous source category."
         },
         {
           "title": "Metadata",
@@ -768,7 +793,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Specify any additional information such as TLP, confidence score, etc., in the JSON format to be included with the object while creating records."
+          "tooltip": "Specify any additional information such as TLP, confidence score, etc., in the JSON format to be included with the object while creating records.",
+          "description": "Specify any additional information such as TLP, confidence score, etc., in the JSON format to be included with the object while creating records."
         },
         {
           "title": "Create Records",
@@ -778,7 +804,8 @@
           "visible": true,
           "editable": true,
           "value": false,
-          "tooltip": "Select this checkbox, i.e., set it to 'True', if you want to create records of the IOCs that were not present in the CTIX platform while performing the lookup. By default this checkbox is not selected, i.e. it is set as 'False'."
+          "tooltip": "Select this checkbox, i.e., set it to 'True', if you want to create records of the IOCs that were not present in the CTIX platform while performing the lookup. By default this checkbox is not selected, i.e. it is set as 'False'.",
+          "description": "Select this checkbox, i.e., set it to 'True', if you want to create records of the IOCs that were not present in the CTIX platform while performing the lookup. By default this checkbox is not selected, i.e. it is set as 'False'."
         },
         {
           "title": "Enrich Records",
@@ -788,7 +815,8 @@
           "visible": true,
           "editable": true,
           "value": false,
-          "tooltip": "Select this checkbox, i.e., set it to 'True', to add the last enriched information for each enriched object found during the lookup. By default this checkbox is not selected, i.e. it is set as 'False'."
+          "tooltip": "Select this checkbox, i.e., set it to 'True', to add the last enriched information for each enriched object found during the lookup. By default this checkbox is not selected, i.e. it is set as 'False'.",
+          "description": "Select this checkbox, i.e., set it to 'True', to add the last enriched information for each enriched object found during the lookup. By default this checkbox is not selected, i.e. it is set as 'False'."
         }
       ],
       "output_schema": {
@@ -808,6 +836,8 @@
     {
       "title": "Bulk IOC Lookup (Advanced)",
       "operation": "bulk_ioc_lookup_advanced",
+      "category": "investigation",
+      "annotation": "bulk_ioc_lookup_advanced",
       "description": "Performs a lookup for threat data objects in the CTIX platform and retrieves the details of the objects, such as basic details, enriched data, and relations.",
       "parameters": [
         {
@@ -818,7 +848,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass an object type to lookup. For the list of supported object types, see Supported SDO Types in Threat Data > Miscellaneous."
+          "tooltip": "Specify an object type to lookup. For the list of supported object types, see Supported SDO Types in Threat Data > Miscellaneous.",
+          "description": "Specify an object type to lookup. For the list of supported object types, see Supported SDO Types in Threat Data > Miscellaneous."
         },
         {
           "title": "Value",
@@ -828,7 +859,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass a list of up to 100 threat data object values to look up."
+          "tooltip": "Specify a list of up to 100 threat data object values to look up.",
+          "description": "Specify a list of up to 100 threat data object values to look up."
         },
         {
           "title": "Object ID",
@@ -838,7 +870,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass a list of up to 100 threat data object IDs to look up."
+          "tooltip": "Specify a list of up to 100 threat data object IDs to look up.",
+          "description": "Specify a list of up to 100 threat data object IDs to look up."
         },
         {
           "title": "Enrichment Data",
@@ -848,7 +881,8 @@
           "visible": true,
           "editable": true,
           "value": false,
-          "tooltip": "Pass true to retrieve the latest five enrichment data objects."
+          "tooltip": "Selecting this option true to retrieve the latest five enrichment data objects.",
+          "description": "Selecting this option true to retrieve the latest five enrichment data objects."
         },
         {
           "title": "Relation Data",
@@ -858,7 +892,8 @@
           "visible": true,
           "editable": true,
           "value": false,
-          "tooltip": "Pass true to retrieve the latest 100 relations details."
+          "tooltip": "Selecting this option true to retrieve the latest 100 relations details.",
+          "description": "Selecting this option true to retrieve the latest 100 relations details."
         },
         {
           "title": "Enrichment Tools",
@@ -868,7 +903,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the name of up to five enrichment tools separated by a comma."
+          "tooltip": "Specify the name of up to five enrichment tools separated by a comma.",
+          "description": "Specify the name of up to five enrichment tools separated by a comma."
         },
         {
           "title": "Fields",
@@ -878,9 +914,11 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass a comma-separated list of field names to retrieve specific details of the objects. By default, all fields are retrieved."
+          "tooltip": "Specify a comma-separated list of field names to retrieve specific details of the objects. By default, all fields are retrieved.",
+          "description": "Specify a comma-separated list of field names to retrieve specific details of the objects. By default, all fields are retrieved."
         }
       ],
+      "output_schema": {},
       "open": false
     },
     {
@@ -898,7 +936,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the type of the object such as indicator, vulnerability, malware, and more."
+          "tooltip": "Specify the type of the object such as indicator, vulnerability, malware, and more.",
+          "description": "Specify the type of the object such as indicator, vulnerability, malware, and more."
         },
         {
           "title": "Object ID",
@@ -908,7 +947,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the ID of the object to retrieve the details."
+          "tooltip": "Specify the ID of the object to retrieve the details.",
+          "description": "Specify the ID of the object to retrieve the details."
         }
       ],
       "output_schema": {
@@ -932,7 +972,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the type of the object such as indicator, vulnerability, malware, and more."
+          "tooltip": "Specify the type of the object such as indicator, vulnerability, malware, and more.",
+          "description": "Specify the type of the object such as indicator, vulnerability, malware, and more."
         },
         {
           "title": "Object ID",
@@ -942,7 +983,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the ID of the object to retrieve the details."
+          "tooltip": "Specify the ID of the object to retrieve the details.",
+          "description": "Specify the ID of the object to retrieve the details."
         }
       ],
       "output_schema": {
@@ -958,7 +1000,7 @@
       "title": "Get Relations List of Threat Data Object",
       "operation": "list_relations_of_threat_data_object",
       "description": "Retrieves the list of relations and the relation details of a threat data object.",
-      "category": "",
+      "category": "investigation",
       "annotation": "list_relations_of_threat_data_object",
       "parameters": [
         {
@@ -968,7 +1010,9 @@
           "required": true,
           "visible": true,
           "editable": true,
-          "value": ""
+          "value": "",
+          "description": "Specify the threat data object whose relations you want to retrieve",
+          "tooltip": "Specify the threat data object whose relations you want to retrieve"
         },
         {
           "title": "Object Type",
@@ -977,7 +1021,9 @@
           "required": true,
           "visible": true,
           "editable": true,
-          "value": ""
+          "value": "",
+          "description": "Specifies the category/type of the threat data object.",
+          "tooltip": "Specifies the category/type of the threat data object."
         },
         {
           "title": "Sources",
@@ -987,7 +1033,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the IDs of the sources to filter results."
+          "tooltip": "Specify the IDs of the sources to filter results.",
+          "description": "Specify the IDs of the sources to filter results."
         },
         {
           "title": "Page",
@@ -997,7 +1044,8 @@
           "visible": true,
           "editable": true,
           "value": 1,
-          "tooltip": "Pass the page number to retrieve relations."
+          "description": "Specify the page number to retrieve relations.",
+          "tooltip": "Specify the page number to retrieve relations."
         },
         {
           "title": "Page Size",
@@ -1007,7 +1055,8 @@
           "visible": true,
           "editable": true,
           "value": 10,
-          "tooltip": "Pass the number of records to retrieve per page."
+          "description": "Specify the number of records to retrieve per page.",
+          "tooltip": "Specify the number of records to retrieve per page."
         }
       ],
       "output_schema": {
@@ -1019,8 +1068,8 @@
     {
       "title": "Create Threat Bulletin",
       "operation": "create_threat_bulletin",
-      "description": "Creates a threat bulletin.",
-      "category": "utilities",
+      "description": "Creates a new Threat Bulletin within the Cyware CTIX platform.",
+      "category": "investigation",
       "annotation": "create_threat_bulletin",
       "parameters": [
         {
@@ -1031,7 +1080,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the title for the threat bulletin."
+          "tooltip": "Specify the headline or name of the threat bulletin.",
+          "description": "Specify the headline or name of the threat bulletin."
         },
         {
           "title": "Description",
@@ -1041,7 +1091,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the description for the threat bulletin."
+          "tooltip": "Specify the description for the threat bulletin.",
+          "description": "Specify the description for the threat bulletin."
         },
         {
           "title": "Status",
@@ -1051,7 +1102,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the status of the creation of the threat bulletin."
+          "tooltip": "Specify the status of the creation of the threat bulletin.",
+          "description": "Specify the status of the creation of the threat bulletin."
         },
         {
           "title": "Tlp",
@@ -1061,7 +1113,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the TLP for the threat bulletin"
+          "tooltip": "Specify the TLP for the threat bulletin",
+          "description": "Specify the TLP for the threat bulletin"
         },
         {
           "title": "Server Collections",
@@ -1071,7 +1124,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass the list of server collections"
+          "tooltip": "Specify the list of server collections",
+          "description": "Specify the list of server collections"
         },
         {
           "title": "Tags",
@@ -1081,7 +1135,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass the list of tags"
+          "tooltip": "Specify the CSV list of tags to be added to the threat bulletin.",
+          "description": "Specify the CSV list of tags to be added to the threat bulletin."
         },
         {
           "title": "Attachments",
@@ -1091,7 +1146,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass the list of attachments"
+          "tooltip": "Specify the CSV list of attachments to be added to the threat bulletin.",
+          "description": "Specify the CSV list of attachments to be added to the threat bulletin."
         }
       ],
       "output_schema": {
@@ -1099,7 +1155,7 @@
         "result": {
           "status": "",
           "id": "",
-          "published": false
+          "published": ""
         }
       },
       "open": false
@@ -1107,19 +1163,20 @@
     {
       "title": "Update Threat Bulletin",
       "operation": "update_threat_bulletin",
-      "description": "Updates the threat bulletin.",
-      "category": "utilities",
+      "description": "Update or modify the associated with a specific Threat Bulletin in Cyware CTIX",
+      "category": "investigation",
       "annotation": "update_threat_bulletin",
       "parameters": [
         {
-          "title": "Threat Bulletin Id",
+          "title": "Threat Bulletin ID",
           "type": "text",
           "name": "threat_bulletin_id",
           "required": true,
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Threat Bulletin ID"
+          "tooltip": "Specify the ID of the threat bulletin of Cyware CTIX",
+          "description": "Specify the ID of the threat bulletin of Cyware CTIX"
         },
         {
           "title": "Title",
@@ -1129,7 +1186,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the title for the threat bulletin."
+          "tooltip": "Specify the title for the threat bulletin.",
+          "description": "Specify the title for the threat bulletin."
         },
         {
           "title": "Description",
@@ -1139,7 +1197,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass the description for the threat bulletin."
+          "tooltip": "Specify the description for the threat bulletin.",
+          "description": "Specify the description for the threat bulletin."
         },
         {
           "title": "Status",
@@ -1149,7 +1208,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the status of creation."
+          "description": "Specify the status of creation for the threat bulletin.",
+          "tooltip": "Specify the status of creation for the threat bulletin."
         },
         {
           "title": "Tlp",
@@ -1159,7 +1219,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass the TLP for the threat bulletin."
+          "description": "Specify the TLP for the threat bulletin.",
+          "tooltip": "Specify the TLP for the threat bulletin."
         },
         {
           "title": "Server Collections",
@@ -1169,7 +1230,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass the list of server collections."
+          "tooltip": "Specify the list of server collections.",
+          "description": "Specify the list of server collections."
         },
         {
           "title": "Tags",
@@ -1179,7 +1241,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass the comma-separated list of tags"
+          "tooltip": "Specify the comma-separated list of tags which you want to add for threat bulletin.",
+          "description": "Specify the comma-separated list of tags which you want to add for threat bulletin."
         }
       ],
       "output_schema": {
@@ -1187,8 +1250,8 @@
         "result": {
           "id": "",
           "title": "",
-          "created": 0,
-          "modified": 0,
+          "created": "",
+          "modified": "",
           "report_id": "",
           "created_by": "",
           "modified_by": "",
@@ -1198,12 +1261,12 @@
           "tlp": "",
           "server_collections": "",
           "client_collections": "",
-          "received": false,
+          "received": "",
           "published_on": "",
           "attachments": [],
           "metadata": "",
-          "published": false,
-          "confidence": "="
+          "published": "",
+          "confidence": ""
         }
       },
       "open": false
@@ -1211,6 +1274,8 @@
     {
       "title": "List Rules",
       "operation": "list_rules",
+      "annotation": "list_rules",
+      "category": "investigation",
       "description": "Retrieves a list of rules from the platform.",
       "parameters": [
         {
@@ -1221,7 +1286,8 @@
           "visible": true,
           "editable": true,
           "value": 1,
-          "tooltip": "Pass the page number to retrieve rules."
+          "description": "Specify the page number to retrieve rules.",
+          "tooltip": "Specify the page number to retrieve rules."
         },
         {
           "title": "Page Size",
@@ -1231,7 +1297,8 @@
           "visible": true,
           "editable": true,
           "value": 10,
-          "tooltip": "Pass the number of rules to retrieve per page."
+          "tooltip": "Specify the number of rules to retrieve per page.",
+          "description": "Specify the number of rules to retrieve per page."
         },
         {
           "title": "Source",
@@ -1241,7 +1308,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass a comma-separated list of source IDs to filter rules."
+          "tooltip": "Specify a comma-separated list of source IDs to filter rules.",
+          "description": "Specify a comma-separated list of source IDs to filter rules."
         },
         {
           "title": "Created By ID",
@@ -1251,7 +1319,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the ID of the creator of the rules to filter."
+          "tooltip": "Specify the ID of the creator of the rules to filter.",
+          "description": "Specify the ID of the creator of the rules to filter."
         },
         {
           "title": "Status",
@@ -1261,7 +1330,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the status of the rules. Allowed values: DRAFT, ACTIVE, INACTIVE. By default, rules with all status are retrieved."
+          "tooltip": "Specify the status of the rules. Allowed values: DRAFT, ACTIVE, INACTIVE. By default, rules with all status are retrieved.",
+          "description": "Specify the status of the rules. Allowed values: DRAFT, ACTIVE, INACTIVE. By default, rules with all status are retrieved."
         },
         {
           "title": "Last Active To",
@@ -1271,7 +1341,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass the last active time in EPOCH format to filter rules."
+          "tooltip": "Specify the last active time in EPOCH format to filter rules.",
+          "description": "Specify the last active time in EPOCH format to filter rules."
         },
         {
           "title": "Last Active From",
@@ -1281,7 +1352,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass the last active time in EPOCH format to filter rules."
+          "tooltip": "Specify the last active time in EPOCH format to filter rules.",
+          "description": "Specify the last active time in EPOCH format to filter rules."
         },
         {
           "title": "Created From",
@@ -1291,7 +1363,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass the creation time in EPOCH format to filter rules."
+          "tooltip": "Specify the creation time in EPOCH format to filter rules.",
+          "description": "Specify the creation time in EPOCH format to filter rules."
         },
         {
           "title": "Created To",
@@ -1301,7 +1374,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the creation time in EPOCH format to filter rules."
+          "tooltip": "Specify the creation time in EPOCH format to filter rules.",
+          "description": "Specify the creation time in EPOCH format to filter rules."
         },
         {
           "title": "Is Manual Run",
@@ -1311,26 +1385,27 @@
           "visible": true,
           "editable": true,
           "value": false,
-          "tooltip": "Check to retrieve rules that are configured for manual execution only"
+          "tooltip": "Check to retrieve rules that are configured for manual execution only.",
+          "description": "Check to retrieve rules that are configured for manual execution only."
         }
       ],
       "output_schema": {
-        "next": null,
-        "previous": null,
-        "page_size": 10,
-        "total": 1,
+        "next": "",
+        "previous": "",
+        "page_size": "",
+        "total": "",
         "results": [
           {
             "name": "",
             "source": [],
             "id": "",
-            "is_active": true,
-            "last_activity_on": 0,
-            "ctix_created": 1632767764,
-            "ctix_updated": 1632767764,
-            "is_follow": true,
-            "no_conditions": true,
-            "all_sources_and_collections": false,
+            "is_active": "",
+            "last_activity_on": "",
+            "ctix_created": "",
+            "ctix_updated": "",
+            "is_follow": "",
+            "no_conditions": "",
+            "all_sources_and_collections": "",
             "status": "",
             "tags": [],
             "created_by": {
@@ -1345,16 +1420,17 @@
               "last_name": "",
               "id": ""
             },
-            "trigger_on_update": false
+            "trigger_on_update": ""
           }
         ]
       },
-      "open": false,
-      "category": "investigation"
+      "open": ""
     },
     {
       "title": "Run Rule",
       "operation": "run_rule",
+      "annotation": "run_rule",
+      "category": "investigation",
       "description": "Runs a rule asynchronously on the existing threat data created in the specified time interval.",
       "parameters": [
         {
@@ -1365,7 +1441,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the unique ID of a rule."
+          "tooltip": "Specify the unique ID of a rule which you want to run.",
+          "description": "Specify the unique ID of a rule which you want to run."
         },
         {
           "title": "Start Time",
@@ -1375,7 +1452,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Filters threat data objects that are created after the passed timestamp value."
+          "tooltip": "Filters threat data objects that are created after the passed timestamp value.",
+          "description": "Filters threat data objects that are created after the passed timestamp value."
         },
         {
           "title": "End Time",
@@ -1385,11 +1463,11 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Filters threat data objects that are created before the passed timestamp value."
+          "tooltip": "Filters threat data objects that are created before the passed timestamp value.",
+          "description": "Filters threat data objects that are created before the passed timestamp value."
         }
       ],
-      "open": false,
-      "category": "remediation"
+      "output_schema": {}
     },
     {
       "title": "Get Enrichment Tool List",
@@ -1406,7 +1484,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Specify a list of comma-separated action names, for example: get_ip for IPs, get_domain for Domain, get_url for URL, get_cve for Vulnerability"
+          "tooltip": "Specify a list of comma-separated action names, for example: get_ip for IPs, get_domain for Domain, get_url for URL, get_cve for Vulnerability",
+          "description": "Specify a list of comma-separated action names, for example: get_ip for IPs, get_domain for Domain, get_url for URL, get_cve for Vulnerability"
         },
         {
           "title": "Component",
@@ -1416,7 +1495,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Use this filter to get the enrichment tools list by a component. For example, if you specify the component as investigation, it returns only those apps whose enrichment is supported in threat-investigation"
+          "tooltip": "Use this filter to get the enrichment tools list by a component. For example, if you specify the component as investigation, it returns only those apps whose enrichment is supported in threat-investigation",
+          "description": "Use this filter to get the enrichment tools list by a component. For example, if you specify the component as investigation, it returns only those apps whose enrichment is supported in threat-investigation"
         },
         {
           "title": "Full List",
@@ -1426,7 +1506,8 @@
           "visible": true,
           "editable": true,
           "value": "true",
-          "tooltip": "Use this filter to get action separated tools together"
+          "tooltip": "Use this filter to get action separated tools together",
+          "description": "Use this filter to get action separated tools together"
         }
       ],
       "output_schema": {
@@ -1450,7 +1531,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the type of object to retrieve enrichment details."
+          "tooltip": "Specify the type of object to retrieve enrichment details.",
+          "description": "Specify the type of object to retrieve enrichment details."
         },
         {
           "title": "Object ID",
@@ -1460,7 +1542,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the object ID to retrieve the enrichment details."
+          "tooltip": "Specify the object ID to retrieve the enrichment details.",
+          "description": "Specify the object ID to retrieve the enrichment details."
         },
         {
           "title": "Tool ID",
@@ -1470,7 +1553,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the tool ID to retrieve the enrichment details."
+          "tooltip": "Specify the tool ID to retrieve the enrichment details.",
+          "description": "Specify the tool ID to retrieve the enrichment details."
         }
       ],
       "output_schema": {
@@ -1483,7 +1567,7 @@
       "title": "Get Enriched Threat Data",
       "operation": "get_enriched_threat_data",
       "description": "Returns the enriched data of a threat data object using enrichment tools.",
-      "category": "remediation",
+      "category": "investigation",
       "annotation": "get_enriched_threat_data",
       "parameters": [
         {
@@ -1494,7 +1578,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the slug of an enrichment tool to retrieve its enriched data. To retrieve the slug of an enrichment tool, use the GET Enrichment Tools API endpoint."
+          "tooltip": "Specify the slug of an enrichment tool to retrieve its enriched data. To retrieve the slug of an enrichment tool, use the GET Enrichment Tools API endpoint.",
+          "description": "Specify the slug of an enrichment tool to retrieve its enriched data. To retrieve the slug of an enrichment tool, use the GET Enrichment Tools API endpoint."
         },
         {
           "title": "Value",
@@ -1504,7 +1589,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the value of the object. For example, sco, vulnerability, and more."
+          "tooltip": "Specify the value of the object. For example, sco, vulnerability, and more.",
+          "description": "Specify the value of the object. For example, sco, vulnerability, and more."
         },
         {
           "title": "Action Slug",
@@ -1514,7 +1600,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the enrichment action name to retrieve specific details. For example, get_ip for IPs, get_domain for Domain, get_url for URL, get_cve for Vulnerability."
+          "tooltip": "Specify the enrichment action name to retrieve specific details. For example, get_ip for IPs, get_domain for Domain, get_url for URL, get_cve for Vulnerability.",
+          "description": "Specify the enrichment action name to retrieve specific details. For example, get_ip for IPs, get_domain for Domain, get_url for URL, get_cve for Vulnerability."
         },
         {
           "title": "Object ID",
@@ -1524,7 +1611,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the ID of an object id(sco object id for indicators and vulnerability object id for vulnerabilities)"
+          "tooltip": "Specify the ID of an object id(sco object id for indicators and vulnerability object id for vulnerabilities)",
+          "description": "Specify the ID of an object id(sco object id for indicators and vulnerability object id for vulnerabilities)"
         },
         {
           "title": "Object Type",
@@ -1534,7 +1622,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the object type. sdo object type(indicator /or vulnerability)"
+          "tooltip": "Specify the object type. sdo object type(indicator /or vulnerability)",
+          "description": "Specify the object type. sdo object type(indicator /or vulnerability)"
         }
       ],
       "output_schema": {
@@ -1547,7 +1636,7 @@
       "title": "Add Note to Threat Data Object",
       "operation": "add_note_to_threat_data_object",
       "description": "Adds a note to a threat data object",
-      "category": "utilities",
+      "category": "investigation",
       "annotation": "add_note_to_threat_data_object",
       "parameters": [
         {
@@ -1558,7 +1647,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the ID of the threat data object to create the notes. Else, the note is created as a global note."
+          "tooltip": "Specify the ID of the threat data object to create the notes. Else, the note is created as a global note.",
+          "description": "Specify the ID of the threat data object to create the notes. Else, the note is created as a global note."
         },
         {
           "title": "Text",
@@ -1568,7 +1658,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass the description for the notes."
+          "tooltip": "Specify the description for the notes.",
+          "description": "Specify the description for the notes."
         },
         {
           "title": "Type",
@@ -1578,7 +1669,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the type of the note."
+          "tooltip": "Specify the type of the note.",
+          "description": "Specify the type of the note."
         },
         {
           "title": "Meta Data",
@@ -1588,7 +1680,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass the metadata associated with the note."
+          "tooltip": "Specify the metadata associated with the note.",
+          "description": "Specify the metadata associated with the note."
         },
         {
           "title": "Is Json",
@@ -1598,13 +1691,14 @@
           "visible": true,
           "editable": true,
           "value": false,
-          "tooltip": "Pass true if you want to send the note in JSON format."
+          "tooltip": "Selecting this option true if you want to send the note in JSON format.",
+          "description": "Selecting this option true if you want to send the note in JSON format."
         }
       ],
       "output_schema": {
         "message": "",
         "result": {
-          "created": 0,
+          "created": "",
           "created_by": {
             "email": "",
             "first_name": "",
@@ -1612,9 +1706,9 @@
             "last_name": ""
           },
           "id": "",
-          "is_json": false,
-          "meta_data": {},
-          "modified": 0,
+          "is_json": "",
+          "meta_data": "",
+          "modified": "",
           "modified_by": {
             "email": "",
             "first_name": "",
@@ -1644,7 +1738,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass a unique name for the tag within 50 characters."
+          "tooltip": "Specify a unique name for the tag within 50 characters.",
+          "description": "Specify a unique name for the tag within 50 characters."
         },
         {
           "title": "Colour Code",
@@ -1654,7 +1749,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass the HEX key of a color code for the tag.",
+          "tooltip": "Select the HEX key of a color code for the tag.",
+          "description": "Select the HEX key of a color code for the tag.",
           "options": [
             "#5236E2",
             "#0068FA",
@@ -1675,10 +1771,10 @@
           "id": "",
           "name": "",
           "colour_code": "",
-          "created": 0,
+          "created": "",
           "created_by": "",
           "modified_by": "",
-          "modified": 0,
+          "modified": "",
           "type": ""
         }
       },
@@ -1699,7 +1795,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the ID of a tag to delete."
+          "tooltip": "Specify the ID of a tag to delete.",
+          "description": "Specify the ID of a tag to delete."
         }
       ],
       "output_schema": {},
@@ -1720,7 +1817,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass an allowed indicator type to filter result. To retrieve the supported list of allowed indicator types, se the GET List Supported Allowed Indicator Types API."
+          "tooltip": "Specify an allowed indicator type to filter result. To retrieve the supported list of allowed indicator types, se the GET List Supported Allowed Indicator Types API.",
+          "description": "Specify an allowed indicator type to filter result. To retrieve the supported list of allowed indicator types, se the GET List Supported Allowed Indicator Types API."
         },
         {
           "title": "Page",
@@ -1730,7 +1828,8 @@
           "visible": true,
           "editable": true,
           "value": 1,
-          "tooltip": "Pass the page number to retrieve indicators."
+          "tooltip": "Specify the page number to retrieve indicators.",
+          "description": "Specify the page number to retrieve indicators."
         },
         {
           "title": "Page Size",
@@ -1740,7 +1839,8 @@
           "visible": true,
           "editable": true,
           "value": 10,
-          "tooltip": "Pass the number of records to retrieve per page."
+          "tooltip": "Specify the number of records to retrieve per page.",
+          "description": "Specify the number of records to retrieve per page."
         },
         {
           "title": "Created by Id",
@@ -1750,7 +1850,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the ID of a user to filter records by the creator."
+          "tooltip": "Specify the ID of a user to filter records by the creator.",
+          "description": "Specify the ID of a user to filter records by the creator."
         },
         {
           "title": "Modified by Id",
@@ -1760,7 +1861,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the ID of a user to filter records by the modifier."
+          "tooltip": "Specify the ID of a user to filter records by the modifier.",
+          "description": "Specify the ID of a user to filter records by the modifier."
         },
         {
           "title": "Created From",
@@ -1770,7 +1872,9 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the created from time in EPOCH format to filter records based on the created time"
+          "tooltip": "Specify the created from time in EPOCH format to filter records based on the created time",
+          "description": "Specify the created from time in EPOCH format to filter records based on the created time"
+
         },
         {
           "title": "Created To",
@@ -1780,7 +1884,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the created to time in EPOCH format to filter records based on the created time."
+          "tooltip": "Specify the created to time in EPOCH format to filter records based on the created time.",
+          "description": "Specify the created to time in EPOCH format to filter records based on the created time."
         },
         {
           "title": "Last Active From",
@@ -1790,7 +1895,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the last active from time in EPOCH format to filter records based on the last activity time."
+          "tooltip": "Specify the last active from time in EPOCH format to filter records based on the last activity time.",
+          "description": "Specify the last active from time in EPOCH format to filter records based on the last activity time."
         },
         {
           "title": "Last Active To",
@@ -1800,7 +1906,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the last active to time in EPOCH format to filter records based on the last activity time."
+          "tooltip": "Specify the last active to time in EPOCH format to filter records based on the last activity time.",
+          "description": "Specify the last active to time in EPOCH format to filter records based on the last activity time."
         },
         {
           "title": "Sort",
@@ -1810,15 +1917,16 @@
           "visible": true,
           "editable": true,
           "value": "-created",
-          "tooltip": "Pass -created to sort result in descending order based on the created time. Pass created to sort result in ascending order."
+          "tooltip": "Specify -created to sort result in descending order based on the created time. Pass created to sort result in ascending order.",
+          "description": "Specify -created to sort result in descending order based on the created time. Pass created to sort result in ascending order."
         }
       ],
       "output_schema": {
         "next": "",
-        "page_size": 10,
+        "page_size": "",
         "previous": "",
         "results": [],
-        "total": 0
+        "total": ""
       },
       "open": false
     },
@@ -1837,7 +1945,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the ID of an allowed indicator to delete."
+          "tooltip": "Specify the ID of an allowed indicator to delete.",
+          "description": "Specify the ID of an allowed indicator to delete."
         }
       ],
       "output_schema": {
@@ -1860,7 +1969,8 @@
           "visible": true,
           "editable": true,
           "value": "basic",
-          "tooltip": "Pass the type of report to filter reports. Allowed values: basic, advanced"
+          "description": "Specify the type of report to filter reports. Allowed values: basic, advanced",
+          "tooltip": "Specify the type of report to filter reports. Allowed values: basic, advanced"
         },
         {
           "title": "Page",
@@ -1870,7 +1980,8 @@
           "visible": true,
           "editable": true,
           "value": 1,
-          "tooltip": "Pass the page number to retrieve reports."
+          "description": "Specify the page number to retrieve reports.",
+          "tooltip": "Specify the page number to retrieve reports."
         },
         {
           "title": "Page Size",
@@ -1880,7 +1991,8 @@
           "visible": true,
           "editable": true,
           "value": 10,
-          "tooltip": "Pass the number of reports to retrieve per page."
+          "description": "Specify the number of reports to retrieve per page.",
+          "tooltip": "Specify the number of reports to retrieve per page."
         },
         {
           "title": "Repeat Type",
@@ -1890,7 +2002,8 @@
           "visible": true,
           "editable": true,
           "value": "none",
-          "tooltip": "Pass the frequency of the report run schedule. Allowed values: daily, weekly, monthly. Default: none "
+          "description": "Specify the frequency of the report run schedule. Allowed values: daily, weekly, monthly. Default: none ",
+          "tooltip": "Specify the frequency of the report run schedule. Allowed values: daily, weekly, monthly. Default: none "
         },
         {
           "title": "Shared Type",
@@ -1900,7 +2013,8 @@
           "visible": true,
           "editable": true,
           "value": "global",
-          "tooltip": "Pass the visibility of the reports. Allowed values: private, global"
+          "description": "Specify the visibility of the reports. Allowed values: private, global",
+          "tooltip": "Specify the visibility of the reports. Allowed values: private, global"
         },
         {
           "title": "Created By",
@@ -1910,7 +2024,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the ID of the user who created the reports."
+          "description": "Specify the ID of the user who created the reports.",
+          "tooltip": "Specify the ID of the user who created the reports."
         },
         {
           "title": "Modified By",
@@ -1920,7 +2035,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the ID of the user who modified the reports."
+          "description": "Specify the ID of the user who modified the reports.",
+          "tooltip": "Specify the ID of the user who modified the reports."
         },
         {
           "title": "Created To",
@@ -1930,7 +2046,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the created from time of the reports in EPOCH format."
+          "description": "Specify the created from time of the reports in EPOCH format.",
+          "tooltip": "Specify the created from time of the reports in EPOCH format."
         },
         {
           "title": "Created From",
@@ -1940,7 +2057,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the created from time of the reports in EPOCH format."
+          "description": "Specify the created from time of the reports in EPOCH format.",
+          "tooltip": "Specify the created from time of the reports in EPOCH format."
         },
         {
           "title": "Modified From",
@@ -1950,7 +2068,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the modified from time of the reports in EPOCH format."
+          "description": "Specify the modified from time of the reports in EPOCH format.",
+          "tooltip": "Specify the modified from time of the reports in EPOCH format."
         },
         {
           "title": "Modified To",
@@ -1960,7 +2079,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass the modified to time of the reports in EPOCH format."
+          "description": "Specify the modified to time of the reports in EPOCH format.",
+          "tooltip": "Specify the modified to time of the reports in EPOCH format."
         },
         {
           "title": "Date Last Run From",
@@ -1970,7 +2090,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the last run from time of the reports in EPOCH format."
+          "description": "Specify the last run from time of the reports in EPOCH format.",
+          "tooltip": "Specify the last run from time of the reports in EPOCH format."
         },
         {
           "title": "Date Last Run To",
@@ -1980,7 +2101,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the last run to time of the reports in EPOCH format."
+          "tooltip": "Specify the last run to time of the reports in EPOCH format.",
+          "description": "Specify the last run to time of the reports in EPOCH format."
         }
       ],
       "output_schema": {
@@ -2004,7 +2126,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the name of the report."
+          "tooltip": "Specify the name of the report.",
+          "description": "Specify the name of the report."
         },
         {
           "title": "Type",
@@ -2014,7 +2137,8 @@
           "visible": true,
           "editable": false,
           "value": "basic",
-          "tooltip": "Pass the type of report to be created, such as standard or advanced."
+          "tooltip": "Specify the type of report to be created, such as standard or advanced.",
+          "description": "Specify the type of report to be created, such as standard or advanced."
         },
         {
           "title": "Basic Report Type",
@@ -2024,7 +2148,8 @@
           "visible": true,
           "editable": false,
           "value": "custom",
-          "tooltip": "Pass the type of basic report to be created."
+          "tooltip": "Specify the type of basic report to be created.",
+          "description": "Specify the type of basic report to be created."
         },
         {
           "title": "Shared Type",
@@ -2034,7 +2159,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass the share type value. Allowed values: private, global.",
+          "tooltip": "Specify the share type value. Allowed values: private, global.",
+          "description": "Specify the share type value. Allowed values: private, global.",
           "options": [
             "private",
             "global"
@@ -2048,7 +2174,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass the saved search or custom query details used for generating the report."
+          "tooltip": "Specify the saved search or custom query details used for generating the report.",
+          "description": "Specify the saved search or custom query details used for generating the report."
         },
         {
           "title": "Schedule",
@@ -2058,7 +2185,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass the schedule details such as repeat type, start date and time, duration time, duration value, and repeat value."
+          "tooltip": "Specify the schedule details such as repeat type, start date and time, duration time, duration value, and repeat value.",
+          "description": "Specify the schedule details such as repeat type, start date and time, duration time, duration value, and repeat value."
         },
         {
           "title": "File Types",
@@ -2068,7 +2196,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass the report types as a comma separated list, such as csv, xls."
+          "tooltip": "Specify the report types as a comma separated list, such as csv, xls.",
+          "description": "Specify the report types as a comma separated list, such as csv, xls."
         },
         {
           "title": "Columns",
@@ -2078,7 +2207,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass the list of columns to be displayed in a basic report."
+          "tooltip": "Specify the list of columns to be displayed in a basic report.",
+          "description": "Specify the list of columns to be displayed in a basic report."
         },
         {
           "title": "Internal Recipients",
@@ -2088,7 +2218,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass the list of internal recipients with whom to share the report."
+          "tooltip": "Specify the list of internal recipients with whom to share the report.",
+          "description": "Specify the list of internal recipients with whom to share the report."
         },
         {
           "title": "Query Key",
@@ -2098,7 +2229,8 @@
           "visible": true,
           "editable": true,
           "value": "ctix_created",
-          "tooltip": "Pass the key to sort data in the report."
+          "description": "Specify the key to sort data in the report.",
+          "tooltip": "Specify the key to sort data in the report."
         },
         {
           "title": "External Recipients",
@@ -2108,7 +2240,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass the list of external recipients with whom to share the report."
+          "tooltip": "Specify the list of external recipients with whom to share the report.",
+          "description": "Specify the list of external recipients with whom to share the report."
         }
       ],
       "output_schema": {
@@ -2131,7 +2264,9 @@
           "required": true,
           "visible": true,
           "editable": true,
-          "value": ""
+          "value": "",
+          "tooltip": "Specify the ID of the report which you want to and and send to the recipients.",
+          "description": "Specify the ID of the report which you want to and and send to the recipients."
         },
         {
           "title": "Type",
@@ -2141,7 +2276,8 @@
           "visible": true,
           "editable": true,
           "value": "basic",
-          "tooltip": "Pass the type of the report to run. Allowed values: basic, advanced"
+          "tooltip": "Specify the type of the report to run. Allowed values: basic, advanced",
+          "description": "Specify the type of the report to run. Allowed values: basic, advanced"
         },
         {
           "title": "Start Time",
@@ -2151,7 +2287,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the start date and time in EPOCH format from which the report captures data available in CTIX."
+          "tooltip": "Specify the start date and time in EPOCH format from which the report captures data available in CTIX.",
+          "description": "Specify the start date and time in EPOCH format from which the report captures data available in CTIX."
         },
         {
           "title": "End Time",
@@ -2161,7 +2298,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the end date and time in EPOCH format until which the report captures data available in CTIX."
+          "tooltip": "Specify the end date and time in EPOCH format until which the report captures data available in CTIX.",
+          "description": "Specify the end date and time in EPOCH format until which the report captures data available in CTIX."
         },
         {
           "title": "File Types",
@@ -2171,7 +2309,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass the report types. Allowed values: csv, xls"
+          "tooltip": "Specify the report types. Allowed values: csv, xls",
+          "description": "Specify the report types. Allowed values: csv, xls"
         },
         {
           "title": "Internal Recipients",
@@ -2181,7 +2320,8 @@
           "visible": true,
           "editable": true,
           "value": {},
-          "tooltip": "Pass the list of internal recipients with whom to share the report."
+          "tooltip": "Specify the list of internal recipients with whom to share the report.",
+          "description": "Specify the list of internal recipients with whom to share the report."
         },
         {
           "title": "External Recipients",
@@ -2191,7 +2331,8 @@
           "visible": true,
           "editable": true,
           "value": {},
-          "tooltip": "Pass the list of external recipients with whom to share the report."
+          "tooltip": "Specify the list of external recipients with whom to share the report.",
+          "description": "Specify the list of external recipients with whom to share the report."
         }
       ],
       "output_schema": {
@@ -2214,7 +2355,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass a name for the attribute within 100 characters."
+          "tooltip": "Specify a name for the attribute within 100 characters.",
+          "description": "Specify a name for the attribute within 100 characters."
         },
         {
           "title": "Description",
@@ -2224,7 +2366,8 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Pass a description for the attribute within 500 characters."
+          "tooltip": "Specify a description for the attribute within 500 characters.",
+          "description": "Specify a name for the attribute within 100 characters."
         },
         {
           "title": "Type",
@@ -2234,7 +2377,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass the number associated with the type. \n0: Boolean\n1: Integer\n2: String\n3: Single Select\n4: Date\n5: JSON\n6: Float",
+          "tooltip": "Specify the number associated with the type. \n0: Boolean\n1: Integer\n2: String\n3: Single Select\n4: Date\n5: JSON\n6: Float",
+          "description": "Specify the number associated with the type. \n0: Boolean\n1: Integer\n2: String\n3: Single Select\n4: Date\n5: JSON\n6: Float",
           "options": [
             "Boolean",
             "Integer",
@@ -2253,7 +2397,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass the list of choices for a single-select attribute."
+          "tooltip": "Specify the list of choices for a single-select attribute.",
+          "description": "Specify the list of choices for a single-select attribute."
         },
         {
           "title": "Is Actionable",
@@ -2263,7 +2408,8 @@
           "visible": true,
           "editable": true,
           "value": false,
-          "tooltip": "Pass true to enable the custom attribute to be modified in threat data objects. Default value: false"
+          "tooltip": "Specify true to enable the custom attribute to be modified in threat data objects. Default value: false",
+          "description": "Specify true to enable the custom attribute to be modified in threat data objects. Default value: false"
         },
         {
           "title": "Status",
@@ -2273,7 +2419,8 @@
           "visible": true,
           "editable": true,
           "value": "1",
-          "tooltip": "Pass 1 to activate the attribute. Pass 0 to deactivate the attribute."
+          "tooltip": "Specify 1 to activate the attribute. Pass 0 to deactivate the attribute.",
+          "description": "Specify 1 to activate the attribute. Pass 0 to deactivate the attribute."
         },
         {
           "title": "Sdo Objects",
@@ -2283,7 +2430,8 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Pass the list of SDOs on which you want to list this attribute as actionable."
+          "tooltip": "Specify the list of SDOs on which you want to list this attribute as actionable.",
+          "description": "Specify the list of SDOs on which you want to list this attribute as actionable."
         }
       ],
       "output_schema": {
@@ -2292,12 +2440,5 @@
       },
       "open": false
     }
-  ],
-  "active": true,
-  "system": false,
-  "playbook_collections": [],
-  "icon_small": "data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAA3hpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDYuMC1jMDAyIDc5LjE2NDQ2MCwgMjAyMC8wNS8xMi0xNjowNDoxNyAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iIHhtcE1NOk9yaWdpbmFsRG9jdW1lbnRJRD0ieG1wLmRpZDo1MDNhYTZiMy0zYzEzLTQ5YzEtODNiZi00MThjZWIxM2VhNTIiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6MDBFOTYyM0VDRjNDMTFFQTgzQkVBMDJBMEQ4MTQzQ0IiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6MDBFOTYyM0RDRjNDMTFFQTgzQkVBMDJBMEQ4MTQzQ0IiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTkgKE1hY2ludG9zaCkiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDphNDA0MjNjNC01YTE5LTQzM2MtYjNmNS0xZWJiOGRmMTBkM2QiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6NTAzYWE2YjMtM2MxMy00OWMxLTgzYmYtNDE4Y2ViMTNlYTUyIi8+IDwvcmRmOkRlc2NyaXB0aW9uPiA8L3JkZjpSREY+IDwveDp4bXBtZXRhPiA8P3hwYWNrZXQgZW5kPSJyIj8+bDf0HAAAAo5JREFUeNpi/P//PwMtARMDjcGoBaMWjFqAy4Lvb758evSOJhZ8//x3z8yXz659ZWT8f3T522sHP1FoASNyWXT3zNfjy9/ouPDruQkwMTN8ePH7yJLXjIwMrtmSbByMFFnw/9//Lx8+fX7NIqbAxcKOYtbLuz9Z/n/n5GPmEuMlwwIWCPXv778PL3+wMHMfXvza2F+ITxQqfvPo5/fPf2uZ/v/7C+HRPz//b+t79vTmdyMfoYcXvnx8+ZuDl9nAW+jdk59C0mxArkWo8Mb2pz6lUuxcTNA4+P2D8dSq32JK3KJKHDsnvzi7/MWDQ28OL3x97/RnNUue62cYv/3kgluwa9rzJ9e/e+ZLyutzmYeK3Dv1xSxEGBgG5ze/UzDgPrPu7Zz0u5x8TEDTET4ABtSPL3+ZWRh1nPg0bXnXppy/9uG3e5eumDrI3Nf3vosrccAtuH/mq0WkiIIhN8jrfxj4JdmA5j66/I2RiZFXhEXBiHtDzePk7+YoqYiJmVFUEWoEMyujfpSMmLmIqConRERQmoODhxlugZwB18kVb+6c+vLm0a9///7/+PT3z89/f3//A3ri5Z2fD859dSuVWtP4BJJ6oBawsv03dgJ65C+EK6wl8IeTC+giCFfHmpGb8zvcAvccSSkNzr0zXrx/9pOFjdE8TJiVg0lQkt3IT+jx1W/OWZJRXfLsnExfP/yBBg4Q/P3998O911f3vbt39guQ+/LOj/Utj4GMn9/+nlz79uWVN19efPxPFkDJB68f/AImfE5+JkMvoVcPfrBxMp1Z/07NmtfYT4iJiRoZDZ402Xl+icgxP7zAJKfLBYw3quVkOPj398+v7384eDgoL4sYR5stoxaMWkB7CwACDADJjl55J5ruFAAAAABJRU5ErkJggg==",
-  "icon_large": "data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAIAAAD/gAIDAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAA3hpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDYuMC1jMDAyIDc5LjE2NDQ2MCwgMjAyMC8wNS8xMi0xNjowNDoxNyAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iIHhtcE1NOk9yaWdpbmFsRG9jdW1lbnRJRD0ieG1wLmRpZDo1MDNhYTZiMy0zYzEzLTQ5YzEtODNiZi00MThjZWIxM2VhNTIiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6MDBFOTYyMzZDRjNDMTFFQTgzQkVBMDJBMEQ4MTQzQ0IiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6MDBFOTYyMzVDRjNDMTFFQTgzQkVBMDJBMEQ4MTQzQ0IiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTkgKE1hY2ludG9zaCkiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDphNDA0MjNjNC01YTE5LTQzM2MtYjNmNS0xZWJiOGRmMTBkM2QiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6NTAzYWE2YjMtM2MxMy00OWMxLTgzYmYtNDE4Y2ViMTNlYTUyIi8+IDwvcmRmOkRlc2NyaXB0aW9uPiA8L3JkZjpSREY+IDwveDp4bXBtZXRhPiA8P3hwYWNrZXQgZW5kPSJyIj8+weTJGgAACthJREFUeNrsnAtwE2UewPeR3SSbV/Nsk7ZpyxVa2/qiVDlPKUWnoIIC4nF6IqLeoI6OgsghqCA9PEFldBTv4SkDo4AiIgg3CCogFFAUacujYDGlr7R5p2mTTTa7e/82FQvWNoE4c63ff7Y7m02ym+/3/d+7XVwURQxJfEIgBAgWgoVgIVgIFoKFECBYCBaChWAhWAgWQoBgIVgIFoKFYCFYCAGChWAhWAgWgoVgIQQIFoKFYCFYCBaChRDEL5KkHEXg+PZGL9cZkRsUSrMGwepPfPXuoD2AE0TYG4K1IlWFzPAXRBQj/jAuIXASxwmc9QWRz+pDAq7o6kdtB973KI0yMSqIggiLTCPno+LaJ2yf/7sNweqRA++7F5dUf7yq4fjnPsaiVZhVFEOpsrWKNLWvlTu62btq9qmXJp6sP9o5ZGDhF3EDbtPx0IeLG/ZvchgZ6dSXrWNmmqTMhdA9zZGtLzbvfKOFxohJSzJvmWuWq8jfFqxISNjxmn3L042dWLRsVtqUZzNNOdJ+Pn9ir/+DBQ3Vh7wjCtV3vphVPFH7m4AVDQvHdrd/uKjhxBFf/pWaO1/IuvqWlHi+yIWFnatatzzZ6MO4splpk+anp18mx/HBSUuMT+ynQ3/BDs3ADnxU0RAKRMUEpbk2+PpdpyZje16ZfBLwiYNTBtAsLswJvEDLaRzHD2/xaM1U7jUXn0Md3Oi2jJBnXcnwkShksJRSSlLkEDHDgCcQcAdETJTKpTqLjiCSUxuxvpDvtBN4kVJKl2+kVbJBnzrwUb7D29GFE8fZTjbYnrRUM9Ds48NRnCSiLBdo8g2Jckfs+evRwO716YOBnKsVlOxiVMzVGAn6otbLGVDm2OHAzSeauHjtXNuZUIeXV+lIvVVmyKRhp7+N8zs4gugjagiCqEmlNSZJuyvqs0fgjHorzaglnpZIwMlBvZFiptWG8yC01bERVhB4zJIvo6REXLDAm6j0So4NcREeE2lGw5ytCi69rmZYiXLyEuvI+EJhTMKd/O63HZufaDRdLXu2skiZrokEIpDxExSptMR7HF8bt3lp43cbPX4nBz+IxHClWpJ7o3rGyuzKdc4Ni+qZ7rEQPdOKCd0zHcSi0yuyJz+TsW+N4715NglGPLY5r2SyzmFjV1x/gsOE4TeoF3xaQMt7oNR9FVgx+gQkRleUa+d8nJ9ABh/0SPetZR1nKGOmEao+jYmatDDDfjj04q01L088Wbu/fcARQt2z/z3XcyXVbz1epyuiJ8yzwPzLtArL763m4jTjVRZZijxOrXxp/Ildb9o9zogUIwwWKeS6rvbwsc1eqZIE7RS6rUA83zBErHt/X8qb/wd1+dMWgH5qn/+LH8sygRc3Le5KIRWYZPryrHME4+o6OM+GV/+1YfxMS1GZEV6mmKnpy6yls0w7XrV/vsp+ZLvnhpmpt861WK9g+vz60R2+rX9rrK70pafJH3pz+Jh7jVIFGSO4d40ryoo3zk6NK7kRsPVP1duqOiiMKPmTfuL8dE0aDUZ0ZJtHFHCVQVJ6f+rl41NICc6xwn9m1dlrWUuB/MHVuRIah3Pp0qUxP4L/6ExicvuC9Jr/es9WdW6vaC6+XWfMllaudx37tMuH3lyRkX2VIrEWDSHBZBhBnP+RtFzZfW/klN5v2raiee+a1oNrHFOXZY2dobftcQU9Yd0wxYgJpk6/8NYD33+11ZWC0X9emn3TI2kqPdVb3T5e1AAbYx8wkpKB3Z/tSMeR9z1AKrOYmb06N+YxIYk5N0mwDUtsG94VurwGnnuNsv/DytXk9BXZK8ef8LjDnyxv/uMy6yfLmkDXcktUt8xJS2Y/K2ek4rENI8Y9lLppcVPjN759rS7vWRb8Zd1nrtbq9uIHc7xN3ISH0kEL+qyH5LoE0qtju3wRTABCY+4z9R9boBqL2RysoxFBQg8wE1eUa0ofTv3sH/Zv33U7bayjlgUbn748O2YBSW7+FY7VFOzR7FpS66jppJU9J2g45LWM1CzcXciok5NwOurDeNcPJdKLmKRnA3cssZ7e326vCZ381A+cb5prLixT/1rNP5EXIn6OoIhexou764LJItUVZ3w83v1De9tyskRtkmSPUoL1UV1eh7jhXuOv2CnFCYJSSIToTxEHYopcm8xRUTI8Ft2gmE86rGNftH+92gWYII2IYsK2FS2/Kiws72aTKIg8C3URFg0JCiM9rMyQxPHoMmUACUbScppNLik2wG+YbwthfMYopvSRVBjAoXXOvWscFwMLYnYYYldkgCQ7+3r99U8M0w5jJHKJsUBdtjBPkz5Aucd1ClwoXjXJHR1zh/jBdc7kwvrkpRbbtx0kRty2KOOelTmWQgaGuumpBscP4YRhQXAdWao3jxg4b8wpNVz7+PCvvxSa3FL975iBlBHPulZpLVbi8bW1isaprcUKGMbx7b53Hv6h8VgQ6pvWOvabrd7tK1u4i7XNM4c7dlZ0GV3xHTrI6SkpPu2FLCgMIO9dv6AeExOMhlAGPrOnMM5zQxXmrIsYhg9sKRSNP/5BHlTRJB0XLClD3v1K9mtltZ0iv/ufrV+95WIsJOvgveFIqkVW/kja+e257txd6KPU7Z3iQ/q6bl49FENqKXVnhTW2c9Rt2pK7DAfXOw9vdH8x3jHuAVMCmsV6g87qJmdVU4fdHwctAI9DGj1w7zQYcdW0OKta3MdbAFk8vApKNU8eKCgqT2EwMsRHnY3hYJhPoejCCVqSwi/sZcZWP2sLiD0ku2THa/aTX/ohq795SVfn9tzHpj2fqdN3zeGmuWebT4bi7WcJUcFxtJFn+a4eDY5DHUcxdH+1UX14Yc7R/EmaJ7fm9z9yd21byNEBVbTA8YxFrcs1xm87MAAowqKcqNSSBqvMYKUvcLJgnqA1UNal5sp6W3m7M+rt7joYsqSQ1rTUhsAXQ3Sy5MkvwA0DCQV4KDP0GVK1URKXGQpRXuBEnCRiyRS8TJZb5cNc7LCQdgjxadY5AS3orQg/D83mEX3HFhh275Fb8n/xIFAkJhwNJTJKppfD5MNCq6VStczTHLlETJ4WDioSpVmNCSJoLhiF3DSYLvT35+C1uSaphhEFgTEq3U3c8yXVw8eqpy2xmvMSbgSDVu952/HBw2eve9R076vZuIQM+1mZRi7TMUMEFsT4c7d4iAKfN06zb11b9QbvxGXp5Y8lcNH0VGX7xkUNR/Z6rBZF1lUMeEm5TgELNugkoWtBVTt9z11TNQXbO/+y7w5tdPV+q+0Mew9W+ffy4713euyRtXNsd2P7Z2CV786z+RycOJgl4cv3kATuftux5elGRzs7+nbj1MWZkI7Bfogg3233paTRBWNV3fFB/HKt86OFDS1toVHl+mkV1gEbTP//gl/cw8bczZFty5t3vW6HqDvleevUZzOgOoTg1m3XuLsp8q9Z33/7mTszXTFlWeaYGSZ8SNxhiF/Kk9lOHwy8N6fefJl89jtZrTYXH+VJCWnMMIQ68KWja4ompEx+JlNjkmBDRfBLfIwdz4lBv8AL/k5fCAICbKl0So0xxdfKpaRR2NCSSzUPSH9VBlIUfoKOd1+4HnqksGTdrazUKmkZ3V30ShUaBTZEBU/W0yThODzHSygJhmMIFhL0TwMIFoKFYCFYCBYSBAvBQrAQLAQLwUKCYCFYCBaChWAhWEgQLAQLwUKwECwECwmChWAhWAjWoJL/CTAA/x+xZTXF3KcAAAAASUVORK5CYII=",
-  "help_online": "https://docs.fortinet.com/document/fortisoar/1.1.0/cyware-ctix/640/cyware-ctix-v1-1-0",
-  "vendor_version": null
+  ]
 }

--- a/cyware-ctix/info.json
+++ b/cyware-ctix/info.json
@@ -10,7 +10,7 @@
   "category": "Threat Intelligence",
   "icon_small_name": "cyware_ctix_small.png",
   "icon_large_name": "cyware_ctix_large.png",
-  "help_online": "",
+  "id": 148,
   "configuration": {
     "fields": [
       {
@@ -465,8 +465,6 @@
     {
       "title": "Create Intel via Open API",
       "operation": "create_intel_via_open_api",
-      "category": "investigation",
-      "annotation": "create_intel_via_open_api",
       "description": "Create intel with additional details such as the source and collection. You can also include details for each object, such as description, notes, custom attributes, and more.",
       "parameters": [
         {
@@ -477,8 +475,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the title of the intel within 100 characters.",
-          "description": "Specify the title of the intel within 100 characters."
+          "tooltip": "Pass the title of the intel within 100 characters."
         },
         {
           "title": "All SDOS",
@@ -488,8 +485,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Specify the SDO and IOC objects to add to the intel. For more information, see The All SDOs Object.",
-          "description": "Specify the SDO and IOC objects to add to the intel. For more information, see The All SDOs Object."
+          "tooltip": "Pass the SDO and IOC objects to add to the intel. For more information, see The All SDOs Object."
         },
         {
           "title": "Source",
@@ -499,8 +495,7 @@
           "visible": true,
           "editable": true,
           "value": "Miscellaneous",
-          "description": "Specify the name of the source to map the intel.If the passed source name does not exists in the platform, then a new source is automatically created in the Miscellaneous source category.",
-          "tooltip": "Specify the name of the source to map the intel.If the passed source name does not exists in the platform, then a new source is automatically created in the Miscellaneous source category."
+          "tooltip": "Pass the name of the source to map the intel.If the passed source name does not exists in the platform, then a new source is automatically created in the Miscellaneous source category."
         },
         {
           "title": "Collection",
@@ -510,8 +505,7 @@
           "visible": true,
           "editable": true,
           "value": "Free Text",
-          "description": "Specify the name of the source collection to associate with the source.\nIf the passed collection name does not exists in the platform, then a new collection is automatically created.",
-          "tooltip": "Specify the name of the source collection to associate with the source.\nIf the passed collection name does not exists in the platform, then a new collection is automatically created."
+          "tooltip": "Pass the name of the source collection to associate with the source.\nIf the passed collection name does not exists in the platform, then a new collection is automatically created."
         },
         {
           "title": "Metadata",
@@ -521,17 +515,16 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "description": "Specify the additional information to associate with the intel.",
-          "tooltip": "Specify the additional information to associate with the intel."
+          "tooltip": "Pass additional information to associate with the intel."
         }
       ],
-      "output_schema": {}
+      "open": false
     },
     {
       "title": "Get Threat Data",
       "operation": "list_threat_data",
       "description": "Returns a list of threat data objects from the CTIX application. You can retrieve a maximum of 500,000 threat data objects using this API.",
-      "category": "investigation",
+      "category": "",
       "annotation": "list_threat_data",
       "parameters": [
         {
@@ -542,8 +535,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "description": "Specify a CQL query to filter and fetch results.",
-          "tooltip": "Specify a CQL query to filter and fetch results."
+          "tooltip": "Pass a CQL query to filter and fetch results."
         },
         {
           "title": "Page",
@@ -553,8 +545,7 @@
           "visible": true,
           "editable": true,
           "value": 1,
-          "description": "Specify the page number to filter threat data objects by page number.",
-          "tooltip": "Specify the page number to filter threat data objects by page number."
+          "tooltip": "Pass the page number to filter threat data objects by page number."
         },
         {
           "title": "Page Size",
@@ -564,8 +555,7 @@
           "visible": true,
           "editable": true,
           "value": 1,
-          "description": " Specify the number of records per page to filter the threat data objects by page size.",
-          "tooltip": " Specify the number of records per page to filter the threat data objects by page size."
+          "tooltip": " Pass the number of records per page to filter the threat data objects by page size."
         },
         {
           "title": "Page Limit",
@@ -575,8 +565,7 @@
           "visible": true,
           "editable": true,
           "value": 10,
-          "description": "Specify the number of threat data objects to be retrieved.",
-          "tooltip": "Specify the number of threat data objects to be retrieved."
+          "tooltip": "Pass the number of threat data objects to be retrieved."
         },
         {
           "title": "Enrichment",
@@ -586,8 +575,7 @@
           "visible": true,
           "editable": true,
           "value": true,
-          "description": "Selecting this parameter retrieves the details of the last enrichment for objects that can be enriched.",
-          "tooltip": "Selecting this parameter retrieves the details of the last enrichment for objects that can be enriched."
+          "tooltip": "Pass true to retrieve the details of the last enrichment for the objects that can be enriched."
         },
         {
           "title": "Sort",
@@ -597,8 +585,7 @@
           "visible": true,
           "editable": true,
           "value": "-ctix_created",
-          "description": "Specify the sort field you want to use for sorting the threat data response.",
-          "tooltip": "Specify the sort field you want to use for sorting the threat data response."
+          "tooltip": ""
         }
       ],
       "output_schema": {
@@ -611,7 +598,7 @@
       "title": "Bulk Add Relation",
       "operation": "bulk_add_relation",
       "description": "Add a relation to multiple threat data objects.",
-      "category": "investigation",
+      "category": "utilities",
       "annotation": "bulk_add_relation",
       "parameters": [
         {
@@ -622,8 +609,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "description": "Specify the list of threat data object IDs to perform the bulk action. To retrieve a list of object IDs, use the List Threat Data API under the Threat Data section.",
-          "tooltip": "Specify the list of threat data object IDs to perform the bulk action. To retrieve a list of object IDs, use the List Threat Data API under the Threat Data section."
+          "tooltip": "Pass the list of threat data object IDs to perform the bulk action. To retrieve a list of object IDs, use the List Threat Data API under the Threat Data section."
         },
         {
           "title": "Object Type",
@@ -633,8 +619,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the type of threat data objects. To get the list of supported object types, see Supported SDO Types in Threat Data > Miscellaneous.",
-          "description": "Specify the type of threat data objects. To get the list of supported object types, see Supported SDO Types in Threat Data > Miscellaneous."
+          "tooltip": "Pass the type of threat data objects. To get the list of supported object types, see Supported SDO Types in Threat Data > Miscellaneous."
         },
         {
           "title": "Data",
@@ -644,8 +629,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Specify the additional data to pass with the request.",
-          "description": "Specify the additional data to pass with the request."
+          "tooltip": "Pass the additional data to pass with the request."
         }
       ],
       "output_schema": {
@@ -658,7 +642,7 @@
       "title": "Bulk Deprecate/Undeprecate Objects",
       "operation": "bulk_deprecate_undeprecate_objects",
       "description": "Deprecate or undeprecate multiple threat data objects with one API request.",
-      "category": "investigation",
+      "category": "utilities",
       "annotation": "bulk_deprecate_undeprecate_objects",
       "parameters": [
         {
@@ -669,8 +653,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "description": "Specify the list of threat data object IDs to perform the bulk action. To retrieve a list of object IDs, use the List Threat Data API under the Threat Data section.",
-          "tooltip": "Specify the list of threat data object IDs to perform the bulk action. To retrieve a list of object IDs, use the List Threat Data API under the Threat Data section."
+          "tooltip": "Pass the list of threat data object IDs to perform the bulk action. To retrieve a list of object IDs, use the List Threat Data API under the Threat Data section."
         },
         {
           "title": "Object Type",
@@ -680,8 +663,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "description": "Specify the type of threat data objects. To get the list of supported object types, see Supported SDO Types in Threat Data > Miscellaneous.",
-          "tooltip": "Specify the type of threat data objects. To get the list of supported object types, see Supported SDO Types in Threat Data > Miscellaneous."
+          "tooltip": "Pass the type of threat data objects. To get the list of supported object types, see Supported SDO Types in Threat Data > Miscellaneous."
         },
         {
           "title": "Action Type",
@@ -691,8 +673,7 @@
           "visible": true,
           "editable": true,
           "value": "deprecate",
-          "description": "Specify deprecate objects. Pass un_deprecate to undeprecate objects.",
-          "tooltip": "Specify deprecate objects. Pass un_deprecate to undeprecate objects."
+          "tooltip": "Pass deprecate objects. Pass un_deprecate to undeprecate objects."
         }
       ],
       "output_schema": {
@@ -715,8 +696,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "description": "Specify the list of threat data object IDs to perform the bulk action. To retrieve a list of object IDs, use the List Threat Data API under the Threat Data section",
-          "tooltip": "Specify the list of threat data object IDs to perform the bulk action. To retrieve a list of object IDs, use the List Threat Data API under the Threat Data section"
+          "tooltip": "Pass the list of threat data object IDs to perform the bulk action. To retrieve a list of object IDs, use the List Threat Data API under the Threat Data section"
         },
         {
           "title": "Object Type",
@@ -726,8 +706,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "description": "Specify the type of threat data objects. To get the list of supported object types, see Supported SDO Types in Threat Data > Miscellaneous.",
-          "tooltip": "Specify the type of threat data objects. To get the list of supported object types, see Supported SDO Types in Threat Data > Miscellaneous."
+          "tooltip": "Pass the type of threat data objects. To get the list of supported object types, see Supported SDO Types in Threat Data > Miscellaneous."
         },
         {
           "title": "Action Type",
@@ -737,8 +716,7 @@
           "visible": true,
           "editable": true,
           "value": "false_positive",
-          "description": "Specify false_positive to mark IOCs as false positives. Pass un_false_positive to unmark an IOCs as false positives.",
-          "tooltip": "Specify false_positive to mark IOCs as false positives. Pass un_false_positive to unmark an IOCs as false positives."
+          "tooltip": "Pass false_positive to mark IOCs as false positives. Pass un_false_positive to unmark an IOCs as false positives."
         }
       ],
       "output_schema": {
@@ -760,8 +738,7 @@
           "required": true,
           "visible": true,
           "editable": true,
-          "tooltip": "Specify a comma-separated list of values to be used by IOCs to perform the lookup.",
-          "description": "Specify a comma-separated list of values to be used by IOCs to perform the lookup."
+          "tooltip": "Specify a comma-separated list of values to be used by IOCs to perform the lookup."
         },
         {
           "title": "Source",
@@ -771,8 +748,7 @@
           "visible": true,
           "editable": true,
           "value": "OpenAPI Lookup (OpenAPI)",
-          "tooltip": "Specify the source name that you want to map to the threat data objects.",
-          "description": "Specify the source name that you want to map to the threat data objects."
+          "tooltip": "Specify the source name that you want to map to the threat data objects."
         },
         {
           "title": "Collection",
@@ -782,8 +758,7 @@
           "visible": true,
           "editable": true,
           "value": "OpenAPI Lookup (OpenAPI)",
-          "tooltip": "Specify the collection name that you want to map to the threat data objects. If the passed source name does not exists in the platform, then a new source is automatically created with the suffix (OpenAPI) in the Miscellaneous source category.",
-          "description": "Specify the collection name that you want to map to the threat data objects. If the passed source name does not exists in the platform, then a new source is automatically created with the suffix (OpenAPI) in the Miscellaneous source category."
+          "tooltip": "Specify the collection name that you want to map to the threat data objects. If the passed source name does not exists in the platform, then a new source is automatically created with the suffix (OpenAPI) in the Miscellaneous source category."
         },
         {
           "title": "Metadata",
@@ -793,8 +768,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Specify any additional information such as TLP, confidence score, etc., in the JSON format to be included with the object while creating records.",
-          "description": "Specify any additional information such as TLP, confidence score, etc., in the JSON format to be included with the object while creating records."
+          "tooltip": "Specify any additional information such as TLP, confidence score, etc., in the JSON format to be included with the object while creating records."
         },
         {
           "title": "Create Records",
@@ -804,8 +778,7 @@
           "visible": true,
           "editable": true,
           "value": false,
-          "tooltip": "Select this checkbox, i.e., set it to 'True', if you want to create records of the IOCs that were not present in the CTIX platform while performing the lookup. By default this checkbox is not selected, i.e. it is set as 'False'.",
-          "description": "Select this checkbox, i.e., set it to 'True', if you want to create records of the IOCs that were not present in the CTIX platform while performing the lookup. By default this checkbox is not selected, i.e. it is set as 'False'."
+          "tooltip": "Select this checkbox, i.e., set it to 'True', if you want to create records of the IOCs that were not present in the CTIX platform while performing the lookup. By default this checkbox is not selected, i.e. it is set as 'False'."
         },
         {
           "title": "Enrich Records",
@@ -815,8 +788,7 @@
           "visible": true,
           "editable": true,
           "value": false,
-          "tooltip": "Select this checkbox, i.e., set it to 'True', to add the last enriched information for each enriched object found during the lookup. By default this checkbox is not selected, i.e. it is set as 'False'.",
-          "description": "Select this checkbox, i.e., set it to 'True', to add the last enriched information for each enriched object found during the lookup. By default this checkbox is not selected, i.e. it is set as 'False'."
+          "tooltip": "Select this checkbox, i.e., set it to 'True', to add the last enriched information for each enriched object found during the lookup. By default this checkbox is not selected, i.e. it is set as 'False'."
         }
       ],
       "output_schema": {
@@ -836,8 +808,6 @@
     {
       "title": "Bulk IOC Lookup (Advanced)",
       "operation": "bulk_ioc_lookup_advanced",
-      "category": "investigation",
-      "annotation": "bulk_ioc_lookup_advanced",
       "description": "Performs a lookup for threat data objects in the CTIX platform and retrieves the details of the objects, such as basic details, enriched data, and relations.",
       "parameters": [
         {
@@ -848,8 +818,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify an object type to lookup. For the list of supported object types, see Supported SDO Types in Threat Data > Miscellaneous.",
-          "description": "Specify an object type to lookup. For the list of supported object types, see Supported SDO Types in Threat Data > Miscellaneous."
+          "tooltip": "Pass an object type to lookup. For the list of supported object types, see Supported SDO Types in Threat Data > Miscellaneous."
         },
         {
           "title": "Value",
@@ -859,8 +828,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify a list of up to 100 threat data object values to look up.",
-          "description": "Specify a list of up to 100 threat data object values to look up."
+          "tooltip": "Pass a list of up to 100 threat data object values to look up."
         },
         {
           "title": "Object ID",
@@ -870,8 +838,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify a list of up to 100 threat data object IDs to look up.",
-          "description": "Specify a list of up to 100 threat data object IDs to look up."
+          "tooltip": "Pass a list of up to 100 threat data object IDs to look up."
         },
         {
           "title": "Enrichment Data",
@@ -881,8 +848,7 @@
           "visible": true,
           "editable": true,
           "value": false,
-          "tooltip": "Selecting this option true to retrieve the latest five enrichment data objects.",
-          "description": "Selecting this option true to retrieve the latest five enrichment data objects."
+          "tooltip": "Pass true to retrieve the latest five enrichment data objects."
         },
         {
           "title": "Relation Data",
@@ -892,8 +858,7 @@
           "visible": true,
           "editable": true,
           "value": false,
-          "tooltip": "Selecting this option true to retrieve the latest 100 relations details.",
-          "description": "Selecting this option true to retrieve the latest 100 relations details."
+          "tooltip": "Pass true to retrieve the latest 100 relations details."
         },
         {
           "title": "Enrichment Tools",
@@ -903,8 +868,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the name of up to five enrichment tools separated by a comma.",
-          "description": "Specify the name of up to five enrichment tools separated by a comma."
+          "tooltip": "Pass the name of up to five enrichment tools separated by a comma."
         },
         {
           "title": "Fields",
@@ -914,11 +878,9 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify a comma-separated list of field names to retrieve specific details of the objects. By default, all fields are retrieved.",
-          "description": "Specify a comma-separated list of field names to retrieve specific details of the objects. By default, all fields are retrieved."
+          "tooltip": "Pass a comma-separated list of field names to retrieve specific details of the objects. By default, all fields are retrieved."
         }
       ],
-      "output_schema": {},
       "open": false
     },
     {
@@ -936,8 +898,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the type of the object such as indicator, vulnerability, malware, and more.",
-          "description": "Specify the type of the object such as indicator, vulnerability, malware, and more."
+          "tooltip": "Pass the type of the object such as indicator, vulnerability, malware, and more."
         },
         {
           "title": "Object ID",
@@ -947,8 +908,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the ID of the object to retrieve the details.",
-          "description": "Specify the ID of the object to retrieve the details."
+          "tooltip": "Pass the ID of the object to retrieve the details."
         }
       ],
       "output_schema": {
@@ -972,8 +932,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the type of the object such as indicator, vulnerability, malware, and more.",
-          "description": "Specify the type of the object such as indicator, vulnerability, malware, and more."
+          "tooltip": "Pass the type of the object such as indicator, vulnerability, malware, and more."
         },
         {
           "title": "Object ID",
@@ -983,8 +942,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the ID of the object to retrieve the details.",
-          "description": "Specify the ID of the object to retrieve the details."
+          "tooltip": "Pass the ID of the object to retrieve the details."
         }
       ],
       "output_schema": {
@@ -1000,7 +958,7 @@
       "title": "Get Relations List of Threat Data Object",
       "operation": "list_relations_of_threat_data_object",
       "description": "Retrieves the list of relations and the relation details of a threat data object.",
-      "category": "investigation",
+      "category": "",
       "annotation": "list_relations_of_threat_data_object",
       "parameters": [
         {
@@ -1010,9 +968,7 @@
           "required": true,
           "visible": true,
           "editable": true,
-          "value": "",
-          "description": "Specify the threat data object whose relations you want to retrieve",
-          "tooltip": "Specify the threat data object whose relations you want to retrieve"
+          "value": ""
         },
         {
           "title": "Object Type",
@@ -1021,9 +977,7 @@
           "required": true,
           "visible": true,
           "editable": true,
-          "value": "",
-          "description": "Specifies the category/type of the threat data object.",
-          "tooltip": "Specifies the category/type of the threat data object."
+          "value": ""
         },
         {
           "title": "Sources",
@@ -1033,8 +987,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the IDs of the sources to filter results.",
-          "description": "Specify the IDs of the sources to filter results."
+          "tooltip": "Pass the IDs of the sources to filter results."
         },
         {
           "title": "Page",
@@ -1044,8 +997,7 @@
           "visible": true,
           "editable": true,
           "value": 1,
-          "description": "Specify the page number to retrieve relations.",
-          "tooltip": "Specify the page number to retrieve relations."
+          "tooltip": "Pass the page number to retrieve relations."
         },
         {
           "title": "Page Size",
@@ -1055,8 +1007,7 @@
           "visible": true,
           "editable": true,
           "value": 10,
-          "description": "Specify the number of records to retrieve per page.",
-          "tooltip": "Specify the number of records to retrieve per page."
+          "tooltip": "Pass the number of records to retrieve per page."
         }
       ],
       "output_schema": {
@@ -1068,8 +1019,8 @@
     {
       "title": "Create Threat Bulletin",
       "operation": "create_threat_bulletin",
-      "description": "Creates a new Threat Bulletin within the Cyware CTIX platform.",
-      "category": "investigation",
+      "description": "Creates a threat bulletin.",
+      "category": "utilities",
       "annotation": "create_threat_bulletin",
       "parameters": [
         {
@@ -1080,8 +1031,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the headline or name of the threat bulletin.",
-          "description": "Specify the headline or name of the threat bulletin."
+          "tooltip": "Pass the title for the threat bulletin."
         },
         {
           "title": "Description",
@@ -1091,8 +1041,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the description for the threat bulletin.",
-          "description": "Specify the description for the threat bulletin."
+          "tooltip": "Pass the description for the threat bulletin."
         },
         {
           "title": "Status",
@@ -1102,8 +1051,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the status of the creation of the threat bulletin.",
-          "description": "Specify the status of the creation of the threat bulletin."
+          "tooltip": "Pass the status of the creation of the threat bulletin."
         },
         {
           "title": "Tlp",
@@ -1113,8 +1061,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the TLP for the threat bulletin",
-          "description": "Specify the TLP for the threat bulletin"
+          "tooltip": "Pass the TLP for the threat bulletin"
         },
         {
           "title": "Server Collections",
@@ -1124,8 +1071,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Specify the list of server collections",
-          "description": "Specify the list of server collections"
+          "tooltip": "Pass the list of server collections"
         },
         {
           "title": "Tags",
@@ -1135,8 +1081,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Specify the CSV list of tags to be added to the threat bulletin.",
-          "description": "Specify the CSV list of tags to be added to the threat bulletin."
+          "tooltip": "Pass the list of tags"
         },
         {
           "title": "Attachments",
@@ -1146,8 +1091,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Specify the CSV list of attachments to be added to the threat bulletin.",
-          "description": "Specify the CSV list of attachments to be added to the threat bulletin."
+          "tooltip": "Pass the list of attachments"
         }
       ],
       "output_schema": {
@@ -1155,7 +1099,7 @@
         "result": {
           "status": "",
           "id": "",
-          "published": ""
+          "published": false
         }
       },
       "open": false
@@ -1163,20 +1107,19 @@
     {
       "title": "Update Threat Bulletin",
       "operation": "update_threat_bulletin",
-      "description": "Update or modify the associated with a specific Threat Bulletin in Cyware CTIX",
-      "category": "investigation",
+      "description": "Updates the threat bulletin.",
+      "category": "utilities",
       "annotation": "update_threat_bulletin",
       "parameters": [
         {
-          "title": "Threat Bulletin ID",
+          "title": "Threat Bulletin Id",
           "type": "text",
           "name": "threat_bulletin_id",
           "required": true,
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the ID of the threat bulletin of Cyware CTIX",
-          "description": "Specify the ID of the threat bulletin of Cyware CTIX"
+          "tooltip": "Threat Bulletin ID"
         },
         {
           "title": "Title",
@@ -1186,8 +1129,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the title for the threat bulletin.",
-          "description": "Specify the title for the threat bulletin."
+          "tooltip": "Pass the title for the threat bulletin."
         },
         {
           "title": "Description",
@@ -1197,8 +1139,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Specify the description for the threat bulletin.",
-          "description": "Specify the description for the threat bulletin."
+          "tooltip": "Pass the description for the threat bulletin."
         },
         {
           "title": "Status",
@@ -1208,8 +1149,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "description": "Specify the status of creation for the threat bulletin.",
-          "tooltip": "Specify the status of creation for the threat bulletin."
+          "tooltip": "Pass the status of creation."
         },
         {
           "title": "Tlp",
@@ -1219,8 +1159,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "description": "Specify the TLP for the threat bulletin.",
-          "tooltip": "Specify the TLP for the threat bulletin."
+          "tooltip": "Pass the TLP for the threat bulletin."
         },
         {
           "title": "Server Collections",
@@ -1230,8 +1169,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Specify the list of server collections.",
-          "description": "Specify the list of server collections."
+          "tooltip": "Pass the list of server collections."
         },
         {
           "title": "Tags",
@@ -1241,8 +1179,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Specify the comma-separated list of tags which you want to add for threat bulletin.",
-          "description": "Specify the comma-separated list of tags which you want to add for threat bulletin."
+          "tooltip": "Pass the comma-separated list of tags"
         }
       ],
       "output_schema": {
@@ -1250,8 +1187,8 @@
         "result": {
           "id": "",
           "title": "",
-          "created": "",
-          "modified": "",
+          "created": 0,
+          "modified": 0,
           "report_id": "",
           "created_by": "",
           "modified_by": "",
@@ -1261,12 +1198,12 @@
           "tlp": "",
           "server_collections": "",
           "client_collections": "",
-          "received": "",
+          "received": false,
           "published_on": "",
           "attachments": [],
           "metadata": "",
-          "published": "",
-          "confidence": ""
+          "published": false,
+          "confidence": "="
         }
       },
       "open": false
@@ -1274,8 +1211,6 @@
     {
       "title": "List Rules",
       "operation": "list_rules",
-      "annotation": "list_rules",
-      "category": "investigation",
       "description": "Retrieves a list of rules from the platform.",
       "parameters": [
         {
@@ -1286,8 +1221,7 @@
           "visible": true,
           "editable": true,
           "value": 1,
-          "description": "Specify the page number to retrieve rules.",
-          "tooltip": "Specify the page number to retrieve rules."
+          "tooltip": "Pass the page number to retrieve rules."
         },
         {
           "title": "Page Size",
@@ -1297,8 +1231,7 @@
           "visible": true,
           "editable": true,
           "value": 10,
-          "tooltip": "Specify the number of rules to retrieve per page.",
-          "description": "Specify the number of rules to retrieve per page."
+          "tooltip": "Pass the number of rules to retrieve per page."
         },
         {
           "title": "Source",
@@ -1308,8 +1241,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify a comma-separated list of source IDs to filter rules.",
-          "description": "Specify a comma-separated list of source IDs to filter rules."
+          "tooltip": "Pass a comma-separated list of source IDs to filter rules."
         },
         {
           "title": "Created By ID",
@@ -1319,8 +1251,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the ID of the creator of the rules to filter.",
-          "description": "Specify the ID of the creator of the rules to filter."
+          "tooltip": "Pass the ID of the creator of the rules to filter."
         },
         {
           "title": "Status",
@@ -1330,8 +1261,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the status of the rules. Allowed values: DRAFT, ACTIVE, INACTIVE. By default, rules with all status are retrieved.",
-          "description": "Specify the status of the rules. Allowed values: DRAFT, ACTIVE, INACTIVE. By default, rules with all status are retrieved."
+          "tooltip": "Pass the status of the rules. Allowed values: DRAFT, ACTIVE, INACTIVE. By default, rules with all status are retrieved."
         },
         {
           "title": "Last Active To",
@@ -1341,8 +1271,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Specify the last active time in EPOCH format to filter rules.",
-          "description": "Specify the last active time in EPOCH format to filter rules."
+          "tooltip": "Pass the last active time in EPOCH format to filter rules."
         },
         {
           "title": "Last Active From",
@@ -1352,8 +1281,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Specify the last active time in EPOCH format to filter rules.",
-          "description": "Specify the last active time in EPOCH format to filter rules."
+          "tooltip": "Pass the last active time in EPOCH format to filter rules."
         },
         {
           "title": "Created From",
@@ -1363,8 +1291,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Specify the creation time in EPOCH format to filter rules.",
-          "description": "Specify the creation time in EPOCH format to filter rules."
+          "tooltip": "Pass the creation time in EPOCH format to filter rules."
         },
         {
           "title": "Created To",
@@ -1374,8 +1301,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the creation time in EPOCH format to filter rules.",
-          "description": "Specify the creation time in EPOCH format to filter rules."
+          "tooltip": "Pass the creation time in EPOCH format to filter rules."
         },
         {
           "title": "Is Manual Run",
@@ -1385,27 +1311,26 @@
           "visible": true,
           "editable": true,
           "value": false,
-          "tooltip": "Check to retrieve rules that are configured for manual execution only.",
-          "description": "Check to retrieve rules that are configured for manual execution only."
+          "tooltip": "Check to retrieve rules that are configured for manual execution only"
         }
       ],
       "output_schema": {
-        "next": "",
-        "previous": "",
-        "page_size": "",
-        "total": "",
+        "next": null,
+        "previous": null,
+        "page_size": 10,
+        "total": 1,
         "results": [
           {
             "name": "",
             "source": [],
             "id": "",
-            "is_active": "",
-            "last_activity_on": "",
-            "ctix_created": "",
-            "ctix_updated": "",
-            "is_follow": "",
-            "no_conditions": "",
-            "all_sources_and_collections": "",
+            "is_active": true,
+            "last_activity_on": 0,
+            "ctix_created": 1632767764,
+            "ctix_updated": 1632767764,
+            "is_follow": true,
+            "no_conditions": true,
+            "all_sources_and_collections": false,
             "status": "",
             "tags": [],
             "created_by": {
@@ -1420,17 +1345,16 @@
               "last_name": "",
               "id": ""
             },
-            "trigger_on_update": ""
+            "trigger_on_update": false
           }
         ]
       },
-      "open": ""
+      "open": false,
+      "category": "investigation"
     },
     {
       "title": "Run Rule",
       "operation": "run_rule",
-      "annotation": "run_rule",
-      "category": "investigation",
       "description": "Runs a rule asynchronously on the existing threat data created in the specified time interval.",
       "parameters": [
         {
@@ -1441,8 +1365,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the unique ID of a rule which you want to run.",
-          "description": "Specify the unique ID of a rule which you want to run."
+          "tooltip": "Pass the unique ID of a rule."
         },
         {
           "title": "Start Time",
@@ -1452,8 +1375,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Filters threat data objects that are created after the passed timestamp value.",
-          "description": "Filters threat data objects that are created after the passed timestamp value."
+          "tooltip": "Filters threat data objects that are created after the passed timestamp value."
         },
         {
           "title": "End Time",
@@ -1463,11 +1385,11 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Filters threat data objects that are created before the passed timestamp value.",
-          "description": "Filters threat data objects that are created before the passed timestamp value."
+          "tooltip": "Filters threat data objects that are created before the passed timestamp value."
         }
       ],
-      "output_schema": {}
+      "open": false,
+      "category": "remediation"
     },
     {
       "title": "Get Enrichment Tool List",
@@ -1484,8 +1406,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Specify a list of comma-separated action names, for example: get_ip for IPs, get_domain for Domain, get_url for URL, get_cve for Vulnerability",
-          "description": "Specify a list of comma-separated action names, for example: get_ip for IPs, get_domain for Domain, get_url for URL, get_cve for Vulnerability"
+          "tooltip": "Specify a list of comma-separated action names, for example: get_ip for IPs, get_domain for Domain, get_url for URL, get_cve for Vulnerability"
         },
         {
           "title": "Component",
@@ -1495,8 +1416,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Use this filter to get the enrichment tools list by a component. For example, if you specify the component as investigation, it returns only those apps whose enrichment is supported in threat-investigation",
-          "description": "Use this filter to get the enrichment tools list by a component. For example, if you specify the component as investigation, it returns only those apps whose enrichment is supported in threat-investigation"
+          "tooltip": "Use this filter to get the enrichment tools list by a component. For example, if you specify the component as investigation, it returns only those apps whose enrichment is supported in threat-investigation"
         },
         {
           "title": "Full List",
@@ -1506,8 +1426,7 @@
           "visible": true,
           "editable": true,
           "value": "true",
-          "tooltip": "Use this filter to get action separated tools together",
-          "description": "Use this filter to get action separated tools together"
+          "tooltip": "Use this filter to get action separated tools together"
         }
       ],
       "output_schema": {
@@ -1531,8 +1450,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the type of object to retrieve enrichment details.",
-          "description": "Specify the type of object to retrieve enrichment details."
+          "tooltip": "Pass the type of object to retrieve enrichment details."
         },
         {
           "title": "Object ID",
@@ -1542,8 +1460,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the object ID to retrieve the enrichment details.",
-          "description": "Specify the object ID to retrieve the enrichment details."
+          "tooltip": "Pass the object ID to retrieve the enrichment details."
         },
         {
           "title": "Tool ID",
@@ -1553,8 +1470,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the tool ID to retrieve the enrichment details.",
-          "description": "Specify the tool ID to retrieve the enrichment details."
+          "tooltip": "Pass the tool ID to retrieve the enrichment details."
         }
       ],
       "output_schema": {
@@ -1567,7 +1483,7 @@
       "title": "Get Enriched Threat Data",
       "operation": "get_enriched_threat_data",
       "description": "Returns the enriched data of a threat data object using enrichment tools.",
-      "category": "investigation",
+      "category": "remediation",
       "annotation": "get_enriched_threat_data",
       "parameters": [
         {
@@ -1578,8 +1494,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the slug of an enrichment tool to retrieve its enriched data. To retrieve the slug of an enrichment tool, use the GET Enrichment Tools API endpoint.",
-          "description": "Specify the slug of an enrichment tool to retrieve its enriched data. To retrieve the slug of an enrichment tool, use the GET Enrichment Tools API endpoint."
+          "tooltip": "Pass the slug of an enrichment tool to retrieve its enriched data. To retrieve the slug of an enrichment tool, use the GET Enrichment Tools API endpoint."
         },
         {
           "title": "Value",
@@ -1589,8 +1504,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the value of the object. For example, sco, vulnerability, and more.",
-          "description": "Specify the value of the object. For example, sco, vulnerability, and more."
+          "tooltip": "Pass the value of the object. For example, sco, vulnerability, and more."
         },
         {
           "title": "Action Slug",
@@ -1600,8 +1514,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the enrichment action name to retrieve specific details. For example, get_ip for IPs, get_domain for Domain, get_url for URL, get_cve for Vulnerability.",
-          "description": "Specify the enrichment action name to retrieve specific details. For example, get_ip for IPs, get_domain for Domain, get_url for URL, get_cve for Vulnerability."
+          "tooltip": "Pass the enrichment action name to retrieve specific details. For example, get_ip for IPs, get_domain for Domain, get_url for URL, get_cve for Vulnerability."
         },
         {
           "title": "Object ID",
@@ -1611,8 +1524,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the ID of an object id(sco object id for indicators and vulnerability object id for vulnerabilities)",
-          "description": "Specify the ID of an object id(sco object id for indicators and vulnerability object id for vulnerabilities)"
+          "tooltip": "Pass the ID of an object id(sco object id for indicators and vulnerability object id for vulnerabilities)"
         },
         {
           "title": "Object Type",
@@ -1622,8 +1534,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the object type. sdo object type(indicator /or vulnerability)",
-          "description": "Specify the object type. sdo object type(indicator /or vulnerability)"
+          "tooltip": "Pass the object type. sdo object type(indicator /or vulnerability)"
         }
       ],
       "output_schema": {
@@ -1636,7 +1547,7 @@
       "title": "Add Note to Threat Data Object",
       "operation": "add_note_to_threat_data_object",
       "description": "Adds a note to a threat data object",
-      "category": "investigation",
+      "category": "utilities",
       "annotation": "add_note_to_threat_data_object",
       "parameters": [
         {
@@ -1647,8 +1558,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the ID of the threat data object to create the notes. Else, the note is created as a global note.",
-          "description": "Specify the ID of the threat data object to create the notes. Else, the note is created as a global note."
+          "tooltip": "Pass the ID of the threat data object to create the notes. Else, the note is created as a global note."
         },
         {
           "title": "Text",
@@ -1658,8 +1568,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Specify the description for the notes.",
-          "description": "Specify the description for the notes."
+          "tooltip": "Pass the description for the notes."
         },
         {
           "title": "Type",
@@ -1669,8 +1578,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the type of the note.",
-          "description": "Specify the type of the note."
+          "tooltip": "Pass the type of the note."
         },
         {
           "title": "Meta Data",
@@ -1680,8 +1588,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Specify the metadata associated with the note.",
-          "description": "Specify the metadata associated with the note."
+          "tooltip": "Pass the metadata associated with the note."
         },
         {
           "title": "Is Json",
@@ -1691,14 +1598,13 @@
           "visible": true,
           "editable": true,
           "value": false,
-          "tooltip": "Selecting this option true if you want to send the note in JSON format.",
-          "description": "Selecting this option true if you want to send the note in JSON format."
+          "tooltip": "Pass true if you want to send the note in JSON format."
         }
       ],
       "output_schema": {
         "message": "",
         "result": {
-          "created": "",
+          "created": 0,
           "created_by": {
             "email": "",
             "first_name": "",
@@ -1706,9 +1612,9 @@
             "last_name": ""
           },
           "id": "",
-          "is_json": "",
-          "meta_data": "",
-          "modified": "",
+          "is_json": false,
+          "meta_data": {},
+          "modified": 0,
           "modified_by": {
             "email": "",
             "first_name": "",
@@ -1738,8 +1644,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify a unique name for the tag within 50 characters.",
-          "description": "Specify a unique name for the tag within 50 characters."
+          "tooltip": "Pass a unique name for the tag within 50 characters."
         },
         {
           "title": "Colour Code",
@@ -1749,8 +1654,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Select the HEX key of a color code for the tag.",
-          "description": "Select the HEX key of a color code for the tag.",
+          "tooltip": "Pass the HEX key of a color code for the tag.",
           "options": [
             "#5236E2",
             "#0068FA",
@@ -1771,10 +1675,10 @@
           "id": "",
           "name": "",
           "colour_code": "",
-          "created": "",
+          "created": 0,
           "created_by": "",
           "modified_by": "",
-          "modified": "",
+          "modified": 0,
           "type": ""
         }
       },
@@ -1795,8 +1699,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the ID of a tag to delete.",
-          "description": "Specify the ID of a tag to delete."
+          "tooltip": "Pass the ID of a tag to delete."
         }
       ],
       "output_schema": {},
@@ -1817,8 +1720,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify an allowed indicator type to filter result. To retrieve the supported list of allowed indicator types, se the GET List Supported Allowed Indicator Types API.",
-          "description": "Specify an allowed indicator type to filter result. To retrieve the supported list of allowed indicator types, se the GET List Supported Allowed Indicator Types API."
+          "tooltip": "Pass an allowed indicator type to filter result. To retrieve the supported list of allowed indicator types, se the GET List Supported Allowed Indicator Types API."
         },
         {
           "title": "Page",
@@ -1828,8 +1730,7 @@
           "visible": true,
           "editable": true,
           "value": 1,
-          "tooltip": "Specify the page number to retrieve indicators.",
-          "description": "Specify the page number to retrieve indicators."
+          "tooltip": "Pass the page number to retrieve indicators."
         },
         {
           "title": "Page Size",
@@ -1839,8 +1740,7 @@
           "visible": true,
           "editable": true,
           "value": 10,
-          "tooltip": "Specify the number of records to retrieve per page.",
-          "description": "Specify the number of records to retrieve per page."
+          "tooltip": "Pass the number of records to retrieve per page."
         },
         {
           "title": "Created by Id",
@@ -1850,8 +1750,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the ID of a user to filter records by the creator.",
-          "description": "Specify the ID of a user to filter records by the creator."
+          "tooltip": "Pass the ID of a user to filter records by the creator."
         },
         {
           "title": "Modified by Id",
@@ -1861,8 +1760,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the ID of a user to filter records by the modifier.",
-          "description": "Specify the ID of a user to filter records by the modifier."
+          "tooltip": "Pass the ID of a user to filter records by the modifier."
         },
         {
           "title": "Created From",
@@ -1872,9 +1770,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the created from time in EPOCH format to filter records based on the created time",
-          "description": "Specify the created from time in EPOCH format to filter records based on the created time"
-
+          "tooltip": "Pass the created from time in EPOCH format to filter records based on the created time"
         },
         {
           "title": "Created To",
@@ -1884,8 +1780,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the created to time in EPOCH format to filter records based on the created time.",
-          "description": "Specify the created to time in EPOCH format to filter records based on the created time."
+          "tooltip": "Pass the created to time in EPOCH format to filter records based on the created time."
         },
         {
           "title": "Last Active From",
@@ -1895,8 +1790,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the last active from time in EPOCH format to filter records based on the last activity time.",
-          "description": "Specify the last active from time in EPOCH format to filter records based on the last activity time."
+          "tooltip": "Pass the last active from time in EPOCH format to filter records based on the last activity time."
         },
         {
           "title": "Last Active To",
@@ -1906,8 +1800,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the last active to time in EPOCH format to filter records based on the last activity time.",
-          "description": "Specify the last active to time in EPOCH format to filter records based on the last activity time."
+          "tooltip": "Pass the last active to time in EPOCH format to filter records based on the last activity time."
         },
         {
           "title": "Sort",
@@ -1917,16 +1810,15 @@
           "visible": true,
           "editable": true,
           "value": "-created",
-          "tooltip": "Specify -created to sort result in descending order based on the created time. Pass created to sort result in ascending order.",
-          "description": "Specify -created to sort result in descending order based on the created time. Pass created to sort result in ascending order."
+          "tooltip": "Pass -created to sort result in descending order based on the created time. Pass created to sort result in ascending order."
         }
       ],
       "output_schema": {
         "next": "",
-        "page_size": "",
+        "page_size": 10,
         "previous": "",
         "results": [],
-        "total": ""
+        "total": 0
       },
       "open": false
     },
@@ -1945,8 +1837,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the ID of an allowed indicator to delete.",
-          "description": "Specify the ID of an allowed indicator to delete."
+          "tooltip": "Pass the ID of an allowed indicator to delete."
         }
       ],
       "output_schema": {
@@ -1969,8 +1860,7 @@
           "visible": true,
           "editable": true,
           "value": "basic",
-          "description": "Specify the type of report to filter reports. Allowed values: basic, advanced",
-          "tooltip": "Specify the type of report to filter reports. Allowed values: basic, advanced"
+          "tooltip": "Pass the type of report to filter reports. Allowed values: basic, advanced"
         },
         {
           "title": "Page",
@@ -1980,8 +1870,7 @@
           "visible": true,
           "editable": true,
           "value": 1,
-          "description": "Specify the page number to retrieve reports.",
-          "tooltip": "Specify the page number to retrieve reports."
+          "tooltip": "Pass the page number to retrieve reports."
         },
         {
           "title": "Page Size",
@@ -1991,8 +1880,7 @@
           "visible": true,
           "editable": true,
           "value": 10,
-          "description": "Specify the number of reports to retrieve per page.",
-          "tooltip": "Specify the number of reports to retrieve per page."
+          "tooltip": "Pass the number of reports to retrieve per page."
         },
         {
           "title": "Repeat Type",
@@ -2002,8 +1890,7 @@
           "visible": true,
           "editable": true,
           "value": "none",
-          "description": "Specify the frequency of the report run schedule. Allowed values: daily, weekly, monthly. Default: none ",
-          "tooltip": "Specify the frequency of the report run schedule. Allowed values: daily, weekly, monthly. Default: none "
+          "tooltip": "Pass the frequency of the report run schedule. Allowed values: daily, weekly, monthly. Default: none "
         },
         {
           "title": "Shared Type",
@@ -2013,8 +1900,7 @@
           "visible": true,
           "editable": true,
           "value": "global",
-          "description": "Specify the visibility of the reports. Allowed values: private, global",
-          "tooltip": "Specify the visibility of the reports. Allowed values: private, global"
+          "tooltip": "Pass the visibility of the reports. Allowed values: private, global"
         },
         {
           "title": "Created By",
@@ -2024,8 +1910,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "description": "Specify the ID of the user who created the reports.",
-          "tooltip": "Specify the ID of the user who created the reports."
+          "tooltip": "Pass the ID of the user who created the reports."
         },
         {
           "title": "Modified By",
@@ -2035,8 +1920,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "description": "Specify the ID of the user who modified the reports.",
-          "tooltip": "Specify the ID of the user who modified the reports."
+          "tooltip": "Pass the ID of the user who modified the reports."
         },
         {
           "title": "Created To",
@@ -2046,8 +1930,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "description": "Specify the created from time of the reports in EPOCH format.",
-          "tooltip": "Specify the created from time of the reports in EPOCH format."
+          "tooltip": "Pass the created from time of the reports in EPOCH format."
         },
         {
           "title": "Created From",
@@ -2057,8 +1940,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "description": "Specify the created from time of the reports in EPOCH format.",
-          "tooltip": "Specify the created from time of the reports in EPOCH format."
+          "tooltip": "Pass the created from time of the reports in EPOCH format."
         },
         {
           "title": "Modified From",
@@ -2068,8 +1950,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "description": "Specify the modified from time of the reports in EPOCH format.",
-          "tooltip": "Specify the modified from time of the reports in EPOCH format."
+          "tooltip": "Pass the modified from time of the reports in EPOCH format."
         },
         {
           "title": "Modified To",
@@ -2079,8 +1960,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "description": "Specify the modified to time of the reports in EPOCH format.",
-          "tooltip": "Specify the modified to time of the reports in EPOCH format."
+          "tooltip": "Pass the modified to time of the reports in EPOCH format."
         },
         {
           "title": "Date Last Run From",
@@ -2090,8 +1970,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "description": "Specify the last run from time of the reports in EPOCH format.",
-          "tooltip": "Specify the last run from time of the reports in EPOCH format."
+          "tooltip": "Pass the last run from time of the reports in EPOCH format."
         },
         {
           "title": "Date Last Run To",
@@ -2101,8 +1980,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the last run to time of the reports in EPOCH format.",
-          "description": "Specify the last run to time of the reports in EPOCH format."
+          "tooltip": "Pass the last run to time of the reports in EPOCH format."
         }
       ],
       "output_schema": {
@@ -2126,8 +2004,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the name of the report.",
-          "description": "Specify the name of the report."
+          "tooltip": "Pass the name of the report."
         },
         {
           "title": "Type",
@@ -2137,8 +2014,7 @@
           "visible": true,
           "editable": false,
           "value": "basic",
-          "tooltip": "Specify the type of report to be created, such as standard or advanced.",
-          "description": "Specify the type of report to be created, such as standard or advanced."
+          "tooltip": "Pass the type of report to be created, such as standard or advanced."
         },
         {
           "title": "Basic Report Type",
@@ -2148,8 +2024,7 @@
           "visible": true,
           "editable": false,
           "value": "custom",
-          "tooltip": "Specify the type of basic report to be created.",
-          "description": "Specify the type of basic report to be created."
+          "tooltip": "Pass the type of basic report to be created."
         },
         {
           "title": "Shared Type",
@@ -2159,8 +2034,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Specify the share type value. Allowed values: private, global.",
-          "description": "Specify the share type value. Allowed values: private, global.",
+          "tooltip": "Pass the share type value. Allowed values: private, global.",
           "options": [
             "private",
             "global"
@@ -2174,8 +2048,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Specify the saved search or custom query details used for generating the report.",
-          "description": "Specify the saved search or custom query details used for generating the report."
+          "tooltip": "Pass the saved search or custom query details used for generating the report."
         },
         {
           "title": "Schedule",
@@ -2185,8 +2058,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Specify the schedule details such as repeat type, start date and time, duration time, duration value, and repeat value.",
-          "description": "Specify the schedule details such as repeat type, start date and time, duration time, duration value, and repeat value."
+          "tooltip": "Pass the schedule details such as repeat type, start date and time, duration time, duration value, and repeat value."
         },
         {
           "title": "File Types",
@@ -2196,8 +2068,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Specify the report types as a comma separated list, such as csv, xls.",
-          "description": "Specify the report types as a comma separated list, such as csv, xls."
+          "tooltip": "Pass the report types as a comma separated list, such as csv, xls."
         },
         {
           "title": "Columns",
@@ -2207,8 +2078,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Specify the list of columns to be displayed in a basic report.",
-          "description": "Specify the list of columns to be displayed in a basic report."
+          "tooltip": "Pass the list of columns to be displayed in a basic report."
         },
         {
           "title": "Internal Recipients",
@@ -2218,8 +2088,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Specify the list of internal recipients with whom to share the report.",
-          "description": "Specify the list of internal recipients with whom to share the report."
+          "tooltip": "Pass the list of internal recipients with whom to share the report."
         },
         {
           "title": "Query Key",
@@ -2229,8 +2098,7 @@
           "visible": true,
           "editable": true,
           "value": "ctix_created",
-          "description": "Specify the key to sort data in the report.",
-          "tooltip": "Specify the key to sort data in the report."
+          "tooltip": "Pass the key to sort data in the report."
         },
         {
           "title": "External Recipients",
@@ -2240,8 +2108,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Specify the list of external recipients with whom to share the report.",
-          "description": "Specify the list of external recipients with whom to share the report."
+          "tooltip": "Pass the list of external recipients with whom to share the report."
         }
       ],
       "output_schema": {
@@ -2264,9 +2131,7 @@
           "required": true,
           "visible": true,
           "editable": true,
-          "value": "",
-          "tooltip": "Specify the ID of the report which you want to and and send to the recipients.",
-          "description": "Specify the ID of the report which you want to and and send to the recipients."
+          "value": ""
         },
         {
           "title": "Type",
@@ -2276,8 +2141,7 @@
           "visible": true,
           "editable": true,
           "value": "basic",
-          "tooltip": "Specify the type of the report to run. Allowed values: basic, advanced",
-          "description": "Specify the type of the report to run. Allowed values: basic, advanced"
+          "tooltip": "Pass the type of the report to run. Allowed values: basic, advanced"
         },
         {
           "title": "Start Time",
@@ -2287,8 +2151,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the start date and time in EPOCH format from which the report captures data available in CTIX.",
-          "description": "Specify the start date and time in EPOCH format from which the report captures data available in CTIX."
+          "tooltip": "Pass the start date and time in EPOCH format from which the report captures data available in CTIX."
         },
         {
           "title": "End Time",
@@ -2298,8 +2161,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the end date and time in EPOCH format until which the report captures data available in CTIX.",
-          "description": "Specify the end date and time in EPOCH format until which the report captures data available in CTIX."
+          "tooltip": "Pass the end date and time in EPOCH format until which the report captures data available in CTIX."
         },
         {
           "title": "File Types",
@@ -2309,8 +2171,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify the report types. Allowed values: csv, xls",
-          "description": "Specify the report types. Allowed values: csv, xls"
+          "tooltip": "Pass the report types. Allowed values: csv, xls"
         },
         {
           "title": "Internal Recipients",
@@ -2320,8 +2181,7 @@
           "visible": true,
           "editable": true,
           "value": {},
-          "tooltip": "Specify the list of internal recipients with whom to share the report.",
-          "description": "Specify the list of internal recipients with whom to share the report."
+          "tooltip": "Pass the list of internal recipients with whom to share the report."
         },
         {
           "title": "External Recipients",
@@ -2331,8 +2191,7 @@
           "visible": true,
           "editable": true,
           "value": {},
-          "tooltip": "Specify the list of external recipients with whom to share the report.",
-          "description": "Specify the list of external recipients with whom to share the report."
+          "tooltip": "Pass the list of external recipients with whom to share the report."
         }
       ],
       "output_schema": {
@@ -2355,8 +2214,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify a name for the attribute within 100 characters.",
-          "description": "Specify a name for the attribute within 100 characters."
+          "tooltip": "Pass a name for the attribute within 100 characters."
         },
         {
           "title": "Description",
@@ -2366,8 +2224,7 @@
           "visible": true,
           "editable": true,
           "value": "",
-          "tooltip": "Specify a description for the attribute within 500 characters.",
-          "description": "Specify a name for the attribute within 100 characters."
+          "tooltip": "Pass a description for the attribute within 500 characters."
         },
         {
           "title": "Type",
@@ -2377,8 +2234,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Specify the number associated with the type. \n0: Boolean\n1: Integer\n2: String\n3: Single Select\n4: Date\n5: JSON\n6: Float",
-          "description": "Specify the number associated with the type. \n0: Boolean\n1: Integer\n2: String\n3: Single Select\n4: Date\n5: JSON\n6: Float",
+          "tooltip": "Pass the number associated with the type. \n0: Boolean\n1: Integer\n2: String\n3: Single Select\n4: Date\n5: JSON\n6: Float",
           "options": [
             "Boolean",
             "Integer",
@@ -2397,8 +2253,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Specify the list of choices for a single-select attribute.",
-          "description": "Specify the list of choices for a single-select attribute."
+          "tooltip": "Pass the list of choices for a single-select attribute."
         },
         {
           "title": "Is Actionable",
@@ -2408,8 +2263,7 @@
           "visible": true,
           "editable": true,
           "value": false,
-          "tooltip": "Specify true to enable the custom attribute to be modified in threat data objects. Default value: false",
-          "description": "Specify true to enable the custom attribute to be modified in threat data objects. Default value: false"
+          "tooltip": "Pass true to enable the custom attribute to be modified in threat data objects. Default value: false"
         },
         {
           "title": "Status",
@@ -2419,8 +2273,7 @@
           "visible": true,
           "editable": true,
           "value": "1",
-          "tooltip": "Specify 1 to activate the attribute. Pass 0 to deactivate the attribute.",
-          "description": "Specify 1 to activate the attribute. Pass 0 to deactivate the attribute."
+          "tooltip": "Pass 1 to activate the attribute. Pass 0 to deactivate the attribute."
         },
         {
           "title": "Sdo Objects",
@@ -2430,8 +2283,7 @@
           "visible": true,
           "editable": true,
           "value": null,
-          "tooltip": "Specify the list of SDOs on which you want to list this attribute as actionable.",
-          "description": "Specify the list of SDOs on which you want to list this attribute as actionable."
+          "tooltip": "Pass the list of SDOs on which you want to list this attribute as actionable."
         }
       ],
       "output_schema": {
@@ -2440,5 +2292,12 @@
       },
       "open": false
     }
-  ]
+  ],
+  "active": true,
+  "system": false,
+  "playbook_collections": [],
+  "icon_small": "data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAA3hpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDYuMC1jMDAyIDc5LjE2NDQ2MCwgMjAyMC8wNS8xMi0xNjowNDoxNyAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iIHhtcE1NOk9yaWdpbmFsRG9jdW1lbnRJRD0ieG1wLmRpZDo1MDNhYTZiMy0zYzEzLTQ5YzEtODNiZi00MThjZWIxM2VhNTIiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6MDBFOTYyM0VDRjNDMTFFQTgzQkVBMDJBMEQ4MTQzQ0IiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6MDBFOTYyM0RDRjNDMTFFQTgzQkVBMDJBMEQ4MTQzQ0IiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTkgKE1hY2ludG9zaCkiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDphNDA0MjNjNC01YTE5LTQzM2MtYjNmNS0xZWJiOGRmMTBkM2QiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6NTAzYWE2YjMtM2MxMy00OWMxLTgzYmYtNDE4Y2ViMTNlYTUyIi8+IDwvcmRmOkRlc2NyaXB0aW9uPiA8L3JkZjpSREY+IDwveDp4bXBtZXRhPiA8P3hwYWNrZXQgZW5kPSJyIj8+bDf0HAAAAo5JREFUeNpi/P//PwMtARMDjcGoBaMWjFqAy4Lvb758evSOJhZ8//x3z8yXz659ZWT8f3T522sHP1FoASNyWXT3zNfjy9/ouPDruQkwMTN8ePH7yJLXjIwMrtmSbByMFFnw/9//Lx8+fX7NIqbAxcKOYtbLuz9Z/n/n5GPmEuMlwwIWCPXv778PL3+wMHMfXvza2F+ITxQqfvPo5/fPf2uZ/v/7C+HRPz//b+t79vTmdyMfoYcXvnx8+ZuDl9nAW+jdk59C0mxArkWo8Mb2pz6lUuxcTNA4+P2D8dSq32JK3KJKHDsnvzi7/MWDQ28OL3x97/RnNUue62cYv/3kgluwa9rzJ9e/e+ZLyutzmYeK3Dv1xSxEGBgG5ze/UzDgPrPu7Zz0u5x8TEDTET4ABtSPL3+ZWRh1nPg0bXnXppy/9uG3e5eumDrI3Nf3vosrccAtuH/mq0WkiIIhN8jrfxj4JdmA5j66/I2RiZFXhEXBiHtDzePk7+YoqYiJmVFUEWoEMyujfpSMmLmIqConRERQmoODhxlugZwB18kVb+6c+vLm0a9///7/+PT3z89/f3//A3ri5Z2fD859dSuVWtP4BJJ6oBawsv03dgJ65C+EK6wl8IeTC+giCFfHmpGb8zvcAvccSSkNzr0zXrx/9pOFjdE8TJiVg0lQkt3IT+jx1W/OWZJRXfLsnExfP/yBBg4Q/P3998O911f3vbt39guQ+/LOj/Utj4GMn9/+nlz79uWVN19efPxPFkDJB68f/AImfE5+JkMvoVcPfrBxMp1Z/07NmtfYT4iJiRoZDZ402Xl+icgxP7zAJKfLBYw3quVkOPj398+v7384eDgoL4sYR5stoxaMWkB7CwACDADJjl55J5ruFAAAAABJRU5ErkJggg==",
+  "icon_large": "data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAIAAAD/gAIDAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAA3hpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDYuMC1jMDAyIDc5LjE2NDQ2MCwgMjAyMC8wNS8xMi0xNjowNDoxNyAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iIHhtcE1NOk9yaWdpbmFsRG9jdW1lbnRJRD0ieG1wLmRpZDo1MDNhYTZiMy0zYzEzLTQ5YzEtODNiZi00MThjZWIxM2VhNTIiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6MDBFOTYyMzZDRjNDMTFFQTgzQkVBMDJBMEQ4MTQzQ0IiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6MDBFOTYyMzVDRjNDMTFFQTgzQkVBMDJBMEQ4MTQzQ0IiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTkgKE1hY2ludG9zaCkiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDphNDA0MjNjNC01YTE5LTQzM2MtYjNmNS0xZWJiOGRmMTBkM2QiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6NTAzYWE2YjMtM2MxMy00OWMxLTgzYmYtNDE4Y2ViMTNlYTUyIi8+IDwvcmRmOkRlc2NyaXB0aW9uPiA8L3JkZjpSREY+IDwveDp4bXBtZXRhPiA8P3hwYWNrZXQgZW5kPSJyIj8+weTJGgAACthJREFUeNrsnAtwE2UewPeR3SSbV/Nsk7ZpyxVa2/qiVDlPKUWnoIIC4nF6IqLeoI6OgsghqCA9PEFldBTv4SkDo4AiIgg3CCogFFAUacujYDGlr7R5p2mTTTa7e/82FQvWNoE4c63ff7Y7m02ym+/3/d+7XVwURQxJfEIgBAgWgoVgIVgIFoKFECBYCBaChWAhWAgWQoBgIVgIFoKFYCFYCAGChWAhWAgWgoVgIQQIFoKFYCFYCBaChRDEL5KkHEXg+PZGL9cZkRsUSrMGwepPfPXuoD2AE0TYG4K1IlWFzPAXRBQj/jAuIXASxwmc9QWRz+pDAq7o6kdtB973KI0yMSqIggiLTCPno+LaJ2yf/7sNweqRA++7F5dUf7yq4fjnPsaiVZhVFEOpsrWKNLWvlTu62btq9qmXJp6sP9o5ZGDhF3EDbtPx0IeLG/ZvchgZ6dSXrWNmmqTMhdA9zZGtLzbvfKOFxohJSzJvmWuWq8jfFqxISNjxmn3L042dWLRsVtqUZzNNOdJ+Pn9ir/+DBQ3Vh7wjCtV3vphVPFH7m4AVDQvHdrd/uKjhxBFf/pWaO1/IuvqWlHi+yIWFnatatzzZ6MO4splpk+anp18mx/HBSUuMT+ynQ3/BDs3ADnxU0RAKRMUEpbk2+PpdpyZje16ZfBLwiYNTBtAsLswJvEDLaRzHD2/xaM1U7jUXn0Md3Oi2jJBnXcnwkShksJRSSlLkEDHDgCcQcAdETJTKpTqLjiCSUxuxvpDvtBN4kVJKl2+kVbJBnzrwUb7D29GFE8fZTjbYnrRUM9Ds48NRnCSiLBdo8g2Jckfs+evRwO716YOBnKsVlOxiVMzVGAn6otbLGVDm2OHAzSeauHjtXNuZUIeXV+lIvVVmyKRhp7+N8zs4gugjagiCqEmlNSZJuyvqs0fgjHorzaglnpZIwMlBvZFiptWG8yC01bERVhB4zJIvo6REXLDAm6j0So4NcREeE2lGw5ytCi69rmZYiXLyEuvI+EJhTMKd/O63HZufaDRdLXu2skiZrokEIpDxExSptMR7HF8bt3lp43cbPX4nBz+IxHClWpJ7o3rGyuzKdc4Ni+qZ7rEQPdOKCd0zHcSi0yuyJz+TsW+N4715NglGPLY5r2SyzmFjV1x/gsOE4TeoF3xaQMt7oNR9FVgx+gQkRleUa+d8nJ9ABh/0SPetZR1nKGOmEao+jYmatDDDfjj04q01L088Wbu/fcARQt2z/z3XcyXVbz1epyuiJ8yzwPzLtArL763m4jTjVRZZijxOrXxp/Ildb9o9zogUIwwWKeS6rvbwsc1eqZIE7RS6rUA83zBErHt/X8qb/wd1+dMWgH5qn/+LH8sygRc3Le5KIRWYZPryrHME4+o6OM+GV/+1YfxMS1GZEV6mmKnpy6yls0w7XrV/vsp+ZLvnhpmpt861WK9g+vz60R2+rX9rrK70pafJH3pz+Jh7jVIFGSO4d40ryoo3zk6NK7kRsPVP1duqOiiMKPmTfuL8dE0aDUZ0ZJtHFHCVQVJ6f+rl41NICc6xwn9m1dlrWUuB/MHVuRIah3Pp0qUxP4L/6ExicvuC9Jr/es9WdW6vaC6+XWfMllaudx37tMuH3lyRkX2VIrEWDSHBZBhBnP+RtFzZfW/klN5v2raiee+a1oNrHFOXZY2dobftcQU9Yd0wxYgJpk6/8NYD33+11ZWC0X9emn3TI2kqPdVb3T5e1AAbYx8wkpKB3Z/tSMeR9z1AKrOYmb06N+YxIYk5N0mwDUtsG94VurwGnnuNsv/DytXk9BXZK8ef8LjDnyxv/uMy6yfLmkDXcktUt8xJS2Y/K2ek4rENI8Y9lLppcVPjN759rS7vWRb8Zd1nrtbq9uIHc7xN3ISH0kEL+qyH5LoE0qtju3wRTABCY+4z9R9boBqL2RysoxFBQg8wE1eUa0ofTv3sH/Zv33U7bayjlgUbn748O2YBSW7+FY7VFOzR7FpS66jppJU9J2g45LWM1CzcXciok5NwOurDeNcPJdKLmKRnA3cssZ7e326vCZ381A+cb5prLixT/1rNP5EXIn6OoIhexou764LJItUVZ3w83v1De9tyskRtkmSPUoL1UV1eh7jhXuOv2CnFCYJSSIToTxEHYopcm8xRUTI8Ft2gmE86rGNftH+92gWYII2IYsK2FS2/Kiws72aTKIg8C3URFg0JCiM9rMyQxPHoMmUACUbScppNLik2wG+YbwthfMYopvSRVBjAoXXOvWscFwMLYnYYYldkgCQ7+3r99U8M0w5jJHKJsUBdtjBPkz5Aucd1ClwoXjXJHR1zh/jBdc7kwvrkpRbbtx0kRty2KOOelTmWQgaGuumpBscP4YRhQXAdWao3jxg4b8wpNVz7+PCvvxSa3FL975iBlBHPulZpLVbi8bW1isaprcUKGMbx7b53Hv6h8VgQ6pvWOvabrd7tK1u4i7XNM4c7dlZ0GV3xHTrI6SkpPu2FLCgMIO9dv6AeExOMhlAGPrOnMM5zQxXmrIsYhg9sKRSNP/5BHlTRJB0XLClD3v1K9mtltZ0iv/ufrV+95WIsJOvgveFIqkVW/kja+e257txd6KPU7Z3iQ/q6bl49FENqKXVnhTW2c9Rt2pK7DAfXOw9vdH8x3jHuAVMCmsV6g87qJmdVU4fdHwctAI9DGj1w7zQYcdW0OKta3MdbAFk8vApKNU8eKCgqT2EwMsRHnY3hYJhPoejCCVqSwi/sZcZWP2sLiD0ku2THa/aTX/ohq795SVfn9tzHpj2fqdN3zeGmuWebT4bi7WcJUcFxtJFn+a4eDY5DHUcxdH+1UX14Yc7R/EmaJ7fm9z9yd21byNEBVbTA8YxFrcs1xm87MAAowqKcqNSSBqvMYKUvcLJgnqA1UNal5sp6W3m7M+rt7joYsqSQ1rTUhsAXQ3Sy5MkvwA0DCQV4KDP0GVK1URKXGQpRXuBEnCRiyRS8TJZb5cNc7LCQdgjxadY5AS3orQg/D83mEX3HFhh275Fb8n/xIFAkJhwNJTJKppfD5MNCq6VStczTHLlETJ4WDioSpVmNCSJoLhiF3DSYLvT35+C1uSaphhEFgTEq3U3c8yXVw8eqpy2xmvMSbgSDVu952/HBw2eve9R076vZuIQM+1mZRi7TMUMEFsT4c7d4iAKfN06zb11b9QbvxGXp5Y8lcNH0VGX7xkUNR/Z6rBZF1lUMeEm5TgELNugkoWtBVTt9z11TNQXbO/+y7w5tdPV+q+0Mew9W+ffy4713euyRtXNsd2P7Z2CV786z+RycOJgl4cv3kATuftux5elGRzs7+nbj1MWZkI7Bfogg3233paTRBWNV3fFB/HKt86OFDS1toVHl+mkV1gEbTP//gl/cw8bczZFty5t3vW6HqDvleevUZzOgOoTg1m3XuLsp8q9Z33/7mTszXTFlWeaYGSZ8SNxhiF/Kk9lOHwy8N6fefJl89jtZrTYXH+VJCWnMMIQ68KWja4ompEx+JlNjkmBDRfBLfIwdz4lBv8AL/k5fCAICbKl0So0xxdfKpaRR2NCSSzUPSH9VBlIUfoKOd1+4HnqksGTdrazUKmkZ3V30ShUaBTZEBU/W0yThODzHSygJhmMIFhL0TwMIFoKFYCFYCBYSBAvBQrAQLAQLwUKCYCFYCBaChWAhWEgQLAQLwUKwECwECwmChWAhWAjWoJL/CTAA/x+xZTXF3KcAAAAASUVORK5CYII=",
+  "help_online": "https://docs.fortinet.com/document/fortisoar/1.1.0/cyware-ctix/640/cyware-ctix-v1-1-0",
+  "vendor_version": null
 }

--- a/cyware-ctix/operations.py
+++ b/cyware-ctix/operations.py
@@ -78,7 +78,7 @@ class CywareCTIX:
 
 def _check_health(config):
     cyware = CywareCTIX(config)
-    resp = cyware.make_rest_call(endpoint='/ctixapi/openapi/source')
+    resp = cyware.make_rest_call(endpoint='/ctixapi/ping/')
     if resp:
         logger.info('connector available')
         return True

--- a/cyware-ctix/playbooks/playbooks.json
+++ b/cyware-ctix/playbooks/playbooks.json
@@ -3,12 +3,12 @@
   "data": [
     {
       "@type": "WorkflowCollection",
-      "name": "Sample - Cyware CTIX - 1.1.0",
+      "name": "Sample - Cyware CTIX - 2.0.0",
       "description": "Sample playbooks for \"Cyware CTIX\" connector. If you are planning to use any of the sample playbooks in your environment, ensure that you clone those playbooks and move them to a different collection, since the sample playbook collection gets deleted during connector upgrade and delete.",
       "visible": true,
-      "image": null,
+      "image": "data:png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAIAAAD/gAIDAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAA3hpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDYuMC1jMDAyIDc5LjE2NDQ2MCwgMjAyMC8wNS8xMi0xNjowNDoxNyAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iIHhtcE1NOk9yaWdpbmFsRG9jdW1lbnRJRD0ieG1wLmRpZDo1MDNhYTZiMy0zYzEzLTQ5YzEtODNiZi00MThjZWIxM2VhNTIiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6MDBFOTYyMzZDRjNDMTFFQTgzQkVBMDJBMEQ4MTQzQ0IiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6MDBFOTYyMzVDRjNDMTFFQTgzQkVBMDJBMEQ4MTQzQ0IiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTkgKE1hY2ludG9zaCkiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDphNDA0MjNjNC01YTE5LTQzM2MtYjNmNS0xZWJiOGRmMTBkM2QiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6NTAzYWE2YjMtM2MxMy00OWMxLTgzYmYtNDE4Y2ViMTNlYTUyIi8+IDwvcmRmOkRlc2NyaXB0aW9uPiA8L3JkZjpSREY+IDwveDp4bXBtZXRhPiA8P3hwYWNrZXQgZW5kPSJyIj8+weTJGgAACthJREFUeNrsnAtwE2UewPeR3SSbV/Nsk7ZpyxVa2/qiVDlPKUWnoIIC4nF6IqLeoI6OgsghqCA9PEFldBTv4SkDo4AiIgg3CCogFFAUacujYDGlr7R5p2mTTTa7e/82FQvWNoE4c63ff7Y7m02ym+/3/d+7XVwURQxJfEIgBAgWgoVgIVgIFoKFECBYCBaChWAhWAgWQoBgIVgIFoKFYCFYCAGChWAhWAgWgoVgIQQIFoKFYCFYCBaChRDEL5KkHEXg+PZGL9cZkRsUSrMGwepPfPXuoD2AE0TYG4K1IlWFzPAXRBQj/jAuIXASxwmc9QWRz+pDAq7o6kdtB973KI0yMSqIggiLTCPno+LaJ2yf/7sNweqRA++7F5dUf7yq4fjnPsaiVZhVFEOpsrWKNLWvlTu62btq9qmXJp6sP9o5ZGDhF3EDbtPx0IeLG/ZvchgZ6dSXrWNmmqTMhdA9zZGtLzbvfKOFxohJSzJvmWuWq8jfFqxISNjxmn3L042dWLRsVtqUZzNNOdJ+Pn9ir/+DBQ3Vh7wjCtV3vphVPFH7m4AVDQvHdrd/uKjhxBFf/pWaO1/IuvqWlHi+yIWFnatatzzZ6MO4splpk+anp18mx/HBSUuMT+ynQ3/BDs3ADnxU0RAKRMUEpbk2+PpdpyZje16ZfBLwiYNTBtAsLswJvEDLaRzHD2/xaM1U7jUXn0Md3Oi2jJBnXcnwkShksJRSSlLkEDHDgCcQcAdETJTKpTqLjiCSUxuxvpDvtBN4kVJKl2+kVbJBnzrwUb7D29GFE8fZTjbYnrRUM9Ds48NRnCSiLBdo8g2Jckfs+evRwO716YOBnKsVlOxiVMzVGAn6otbLGVDm2OHAzSeauHjtXNuZUIeXV+lIvVVmyKRhp7+N8zs4gugjagiCqEmlNSZJuyvqs0fgjHorzaglnpZIwMlBvZFiptWG8yC01bERVhB4zJIvo6REXLDAm6j0So4NcREeE2lGw5ytCi69rmZYiXLyEuvI+EJhTMKd/O63HZufaDRdLXu2skiZrokEIpDxExSptMR7HF8bt3lp43cbPX4nBz+IxHClWpJ7o3rGyuzKdc4Ni+qZ7rEQPdOKCd0zHcSi0yuyJz+TsW+N4715NglGPLY5r2SyzmFjV1x/gsOE4TeoF3xaQMt7oNR9FVgx+gQkRleUa+d8nJ9ABh/0SPetZR1nKGOmEao+jYmatDDDfjj04q01L088Wbu/fcARQt2z/z3XcyXVbz1epyuiJ8yzwPzLtArL763m4jTjVRZZijxOrXxp/Ildb9o9zogUIwwWKeS6rvbwsc1eqZIE7RS6rUA83zBErHt/X8qb/wd1+dMWgH5qn/+LH8sygRc3Le5KIRWYZPryrHME4+o6OM+GV/+1YfxMS1GZEV6mmKnpy6yls0w7XrV/vsp+ZLvnhpmpt861WK9g+vz60R2+rX9rrK70pafJH3pz+Jh7jVIFGSO4d40ryoo3zk6NK7kRsPVP1duqOiiMKPmTfuL8dE0aDUZ0ZJtHFHCVQVJ6f+rl41NICc6xwn9m1dlrWUuB/MHVuRIah3Pp0qUxP4L/6ExicvuC9Jr/es9WdW6vaC6+XWfMllaudx37tMuH3lyRkX2VIrEWDSHBZBhBnP+RtFzZfW/klN5v2raiee+a1oNrHFOXZY2dobftcQU9Yd0wxYgJpk6/8NYD33+11ZWC0X9emn3TI2kqPdVb3T5e1AAbYx8wkpKB3Z/tSMeR9z1AKrOYmb06N+YxIYk5N0mwDUtsG94VurwGnnuNsv/DytXk9BXZK8ef8LjDnyxv/uMy6yfLmkDXcktUt8xJS2Y/K2ek4rENI8Y9lLppcVPjN759rS7vWRb8Zd1nrtbq9uIHc7xN3ISH0kEL+qyH5LoE0qtju3wRTABCY+4z9R9boBqL2RysoxFBQg8wE1eUa0ofTv3sH/Zv33U7bayjlgUbn748O2YBSW7+FY7VFOzR7FpS66jppJU9J2g45LWM1CzcXciok5NwOurDeNcPJdKLmKRnA3cssZ7e326vCZ381A+cb5prLixT/1rNP5EXIn6OoIhexou764LJItUVZ3w83v1De9tyskRtkmSPUoL1UV1eh7jhXuOv2CnFCYJSSIToTxEHYopcm8xRUTI8Ft2gmE86rGNftH+92gWYII2IYsK2FS2/Kiws72aTKIg8C3URFg0JCiM9rMyQxPHoMmUACUbScppNLik2wG+YbwthfMYopvSRVBjAoXXOvWscFwMLYnYYYldkgCQ7+3r99U8M0w5jJHKJsUBdtjBPkz5Aucd1ClwoXjXJHR1zh/jBdc7kwvrkpRbbtx0kRty2KOOelTmWQgaGuumpBscP4YRhQXAdWao3jxg4b8wpNVz7+PCvvxSa3FL975iBlBHPulZpLVbi8bW1isaprcUKGMbx7b53Hv6h8VgQ6pvWOvabrd7tK1u4i7XNM4c7dlZ0GV3xHTrI6SkpPu2FLCgMIO9dv6AeExOMhlAGPrOnMM5zQxXmrIsYhg9sKRSNP/5BHlTRJB0XLClD3v1K9mtltZ0iv/ufrV+95WIsJOvgveFIqkVW/kja+e257txd6KPU7Z3iQ/q6bl49FENqKXVnhTW2c9Rt2pK7DAfXOw9vdH8x3jHuAVMCmsV6g87qJmdVU4fdHwctAI9DGj1w7zQYcdW0OKta3MdbAFk8vApKNU8eKCgqT2EwMsRHnY3hYJhPoejCCVqSwi/sZcZWP2sLiD0ku2THa/aTX/ohq795SVfn9tzHpj2fqdN3zeGmuWebT4bi7WcJUcFxtJFn+a4eDY5DHUcxdH+1UX14Yc7R/EmaJ7fm9z9yd21byNEBVbTA8YxFrcs1xm87MAAowqKcqNSSBqvMYKUvcLJgnqA1UNal5sp6W3m7M+rt7joYsqSQ1rTUhsAXQ3Sy5MkvwA0DCQV4KDP0GVK1URKXGQpRXuBEnCRiyRS8TJZb5cNc7LCQdgjxadY5AS3orQg/D83mEX3HFhh275Fb8n/xIFAkJhwNJTJKppfD5MNCq6VStczTHLlETJ4WDioSpVmNCSJoLhiF3DSYLvT35+C1uSaphhEFgTEq3U3c8yXVw8eqpy2xmvMSbgSDVu952/HBw2eve9R076vZuIQM+1mZRi7TMUMEFsT4c7d4iAKfN06zb11b9QbvxGXp5Y8lcNH0VGX7xkUNR/Z6rBZF1lUMeEm5TgELNugkoWtBVTt9z11TNQXbO/+y7w5tdPV+q+0Mew9W+ffy4713euyRtXNsd2P7Z2CV786z+RycOJgl4cv3kATuftux5elGRzs7+nbj1MWZkI7Bfogg3233paTRBWNV3fFB/HKt86OFDS1toVHl+mkV1gEbTP//gl/cw8bczZFty5t3vW6HqDvleevUZzOgOoTg1m3XuLsp8q9Z33/7mTszXTFlWeaYGSZ8SNxhiF/Kk9lOHwy8N6fefJl89jtZrTYXH+VJCWnMMIQ68KWja4ompEx+JlNjkmBDRfBLfIwdz4lBv8AL/k5fCAICbKl0So0xxdfKpaRR2NCSSzUPSH9VBlIUfoKOd1+4HnqksGTdrazUKmkZ3V30ShUaBTZEBU/W0yThODzHSygJhmMIFhL0TwMIFoKFYCFYCBYSBAvBQrAQLAQLwUKCYCFYCBaChWAhWEgQLAQLwUKwECwECwmChWAhWAjWoJL/CTAA/x+xZTXF3KcAAAAASUVORK5CYII=",
       "uuid": "95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
-      "id": 296,
+      "id": 409,
       "deletedAt": null,
       "importedBy": [],
       "recordTags": [
@@ -16,6 +16,206 @@
         "cyware-ctix"
       ],
       "workflows": [
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Bulk IOC Lookup (Advanced)",
+          "aliasName": null,
+          "tag": "#Cyware CTIX",
+          "description": "Performs a lookup for threat data objects in the CTIX platform and retrieves the details of the objects, such as basic details, enriched data, and relations.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": null,
+          "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/8aaf9da4-e46e-4533-b202-5b9968cac674",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Bulk IOC Lookup (Advanced)",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "''",
+                "params": {
+                  "value": "",
+                  "fields": "",
+                  "objectID": "",
+                  "object_type": "",
+                  "relation_data": false,
+                  "enrichment_data": false,
+                  "enrichment_tools": ""
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "bulk_ioc_lookup_advanced",
+                "operationTitle": "Bulk IOC Lookup (Advanced)",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "120",
+              "left": "188",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "a3a8c955-77e3-4a4d-a8c9-ddf3a9d79443"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "4aedea24-79b4-4f2a-8879-2280af47a066",
+                "title": "Cyware CTIX: Bulk IOC Lookup (Advanced)",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "8aaf9da4-e46e-4533-b202-5b9968cac674"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start-> Bulk IOC Lookup (Advanced)",
+              "targetStep": "/api/3/workflow_steps/a3a8c955-77e3-4a4d-a8c9-ddf3a9d79443",
+              "sourceStep": "/api/3/workflow_steps/8aaf9da4-e46e-4533-b202-5b9968cac674",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "677da33e-b0c7-4876-a767-2efd4b36e3f3"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "0c4d0419-b3af-4040-a957-d1a234a4866f",
+          "id": 3223,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "Cyware",
+            "cyware-ctix"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Bulk Add Relation",
+          "aliasName": null,
+          "tag": "#Cyware CTIX",
+          "description": "Add a relation to multiple threat data objects.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": null,
+          "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/d9e6e097-ebc4-40f0-9065-4a1c94085c87",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Bulk Add Relation",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "''",
+                "params": {
+                  "data": null,
+                  "object_ids": null,
+                  "object_type": ""
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "bulk_add_relation",
+                "operationTitle": "Bulk Add Relation",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "120",
+              "left": "188",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "75dd68de-2466-4f93-aadf-635af1d7717f"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "d6ea9f24-ed76-4f3b-bdc1-98f8f77575d1",
+                "title": "Cyware CTIX: Bulk Add Relation",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "d9e6e097-ebc4-40f0-9065-4a1c94085c87"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start-> Bulk Add Relation",
+              "targetStep": "/api/3/workflow_steps/75dd68de-2466-4f93-aadf-635af1d7717f",
+              "sourceStep": "/api/3/workflow_steps/d9e6e097-ebc4-40f0-9065-4a1c94085c87",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "915550bf-d8e8-4e24-9fb9-c71da7f59fa6"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "0d6f62c1-7319-46b5-a3bc-d68a81530971",
+          "id": 3219,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "Cyware",
+            "cyware-ctix"
+          ]
+        },
         {
           "@type": "Workflow",
           "triggerLimit": null,
@@ -32,36 +232,31 @@
             "style_colors"
           ],
           "synchronous": false,
-          "lastModifyDate": 1684227623,
+          "lastModifyDate": 1760346564,
           "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
           "versions": [],
           "triggerStep": "/api/3/workflow_steps/9ddf2208-ce2f-466b-bcfb-cbdde2851747",
           "steps": [
             {
               "@type": "WorkflowStep",
-              "name": "Get Reputation",
+              "name": "Compute Enrichment Summary",
               "description": null,
               "arguments": {
-                "name": "Cyware CTIX",
-                "config": "31319c16-be23-43d3-9e71-6d4abbbbf644",
                 "params": {
-                  "hash": "{{vars.indicator_value}}",
-                  "page_size": ""
+                  "value": "<table class=\"no-border\">\n    <tr>\n        <th colspan=\"5\" class=\"no-background padding-0\">\n            <div class=\"font-size-11 ng-binding padding-bottom-sm\">\n                <h4 style=\"color: orange;\"\n                    class=\"body-default-bgcolor margin-bottom-0 padding-bottom-md padding-left-md padding-top-md text-align-left\">\n                    Cyware CTIX Detection Summary</h4>\n            </div>\n        </th>\n    </tr>\n    <tr class=\"solid-border\">\n        <td>\n            <div small class=\"control-label\">Score</div>\n            <div class=\"card-container-body margin-left-0\" style=\"width: 100px;\">\n                <div>{% if vars.steps.Get_Reputation_Hash.data.results[0].score > (vars.malicious_score.split('-')[1] | int) %}</div>\n                <div class=\"body-default-bgcolor card-number padding-left-md\"\n                    style=\"border-left: 5px solid {{vars.input.params.style_colors.Malicious}};padding: 11px;font-size: 18px !important;\">\n                    {{vars.steps.Get_Reputation_Hash.data.results[0].score}}</div>\n                <div>{% elif vars.steps.Get_Reputation_Hash.data.results[0].score > (vars.suspicious_score.split('-')[1] | int) %}</div>\n                <div class=\"body-default-bgcolor card-number padding-left-md\"\n                    style=\"border-left: 5px solid {{vars.input.params.style_colors.Suspicious}};padding: 11px;font-size: 18px !important;\">\n                    {{vars.steps.Get_Reputation_Hash.data.results[0].score}}</div>\n                <div>{% elif vars.steps.Get_Reputation_Hash.data.results[0].score > (vars.good_score.split('-')[1] | int) %}</div>\n                <div class=\"body-default-bgcolor card-number padding-left-md\"\n                    style=\"border-left: 5px solid {{vars.input.params.style_colors.Good}};padding: 11px;font-size: 18px !important;\">\n                    {{vars.steps.Get_Reputation_Hash.data.results[0].score}}</div>\n                <div>{% else %}</div>\n                <div class=\"body-default-bgcolor card-number padding-left-md\"\n                    style=\"border-left: 5px solid {{vars.input.params.style_colors['No Reputation Available']}};padding: 11px;font-size: 18px !important;\">\n                    {{vars.steps.Get_Reputation_Hash.data.results[0].score}}</div>\n                <div>{% endif %}</div>\n            </div>\n        </td>\n    </tr>\n</table>"
                 },
-                "version": "1.1.0",
-                "connector": "cyware-ctix",
-                "operation": "search_hash",
-                "mock_result": "{\n  \"data\":{\n    \"page_limit\":\"\",\n    \"results\":[\n      {\n        \"first_seen\":\"\",\n        \"last_seen\":\"\",\n        \"stix_object_id\":\"\",\n        \"deprecated\":\"\",\n        \"intel_grading\":\"\",\n        \"indicator_type\":\"\",\n        \"package_id\":[\n          \n        ],\n        \"source\":[\n          \n        ],\n        \"labels\":[\n          \n        ],\n        \"source_grading\":\"\",\n        \"score\":82,\n        \"blocked_time\":\"\",\n        \"blocked\":\"\",\n        \"name2\":\"\",\n        \"deprecated_time\":\"\"\n      }\n    ],\n    \"total\":\"\"\n  }\n}",
-                "operationTitle": "Search Hash",
-                "pickFromTenant": false,
+                "version": "3.2.3",
+                "connector": "cyops_utilities",
+                "operation": "format_richtext",
+                "operationTitle": "Utils: Format as RichText (Markdown)",
                 "step_variables": []
               },
               "status": null,
-              "top": "300",
-              "left": "300",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "top": "570",
+              "left": "125",
+              "stepType": "/api/3/workflow_step_types/0109f35d-090b-4a2b-bd8a-94cbc3508562",
               "group": null,
-              "uuid": "034cb284-84e7-4946-8153-a44200d13284"
+              "uuid": "f5ff3c32-df71-4e70-a7de-31110e8164e6"
             },
             {
               "@type": "WorkflowStep",
@@ -75,11 +270,37 @@
                 "suspicious_score": "66-34"
               },
               "status": null,
-              "top": "160",
+              "top": "165",
               "left": "300",
               "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
               "group": null,
               "uuid": "0d6e08c5-6a41-445e-8cbf-0a5d6d014eb4"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Get Reputation",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "98dc98c3-f61d-4268-a31e-3c54ae8f051a",
+                "params": {
+                  "hash": "{{vars.indicator_value}}",
+                  "page_size": ""
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "search_hash",
+                "mock_result": "{\n  \"data\":{\n    \"page_limit\":\"\",\n    \"results\":[\n      {\n        \"first_seen\":\"\",\n        \"last_seen\":\"\",\n        \"stix_object_id\":\"\",\n        \"deprecated\":\"\",\n        \"intel_grading\":\"\",\n        \"indicator_type\":\"\",\n        \"package_id\":[\n          \n        ],\n        \"source\":[\n          \n        ],\n        \"labels\":[\n          \n        ],\n        \"source_grading\":\"\",\n        \"score\":82,\n        \"blocked_time\":\"\",\n        \"blocked\":\"\",\n        \"name2\":\"\",\n        \"deprecated_time\":\"\"\n      }\n    ],\n    \"total\":\"\"\n  }\n}",
+                "operationTitle": "Search Hash",
+                "pickFromTenant": false,
+                "step_variables": []
+              },
+              "status": null,
+              "top": "300",
+              "left": "300",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "d66ba611-1e8c-460a-a81d-1e167357affc"
             },
             {
               "@type": "WorkflowStep",
@@ -90,7 +311,7 @@
                   {
                     "option": "Yes",
                     "step_iri": "/api/3/workflow_steps/f5ff3c32-df71-4e70-a7de-31110e8164e6",
-                    "condition": "{{ (vars.steps.Get_Reputation.data.results | length > 0) and (vars.steps.Get_Reputation.data.results[0].score != null) }}",
+                    "condition": "{{ (vars.steps.Get_Reputation_Hash.data.results | length > 0) and (vars.steps.Get_Reputation_Hash.data.results[0].score != null) }}",
                     "step_name": "Compute Enrichment Summary"
                   },
                   {
@@ -102,7 +323,7 @@
                 ]
               },
               "status": null,
-              "top": "440",
+              "top": "435",
               "left": "300",
               "stepType": "/api/3/workflow_step_types/12254cf5-5db7-4b1a-8cb1-3af081924b28",
               "group": null,
@@ -110,18 +331,37 @@
             },
             {
               "@type": "WorkflowStep",
+              "name": "No Operation",
+              "description": null,
+              "arguments": {
+                "params": [],
+                "version": "3.2.3",
+                "connector": "cyops_utilities",
+                "operation": "no_op",
+                "operationTitle": "Utils: No Operation",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "570",
+              "left": "475",
+              "stepType": "/api/3/workflow_step_types/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+              "group": null,
+              "uuid": "f592bdc6-c846-4029-95ac-5d8558f13c00"
+            },
+            {
+              "@type": "WorkflowStep",
               "name": "Return Output Data",
               "description": null,
               "arguments": {
-                "verdict": "{% if vars.steps.Get_Reputation.data.results[0].score > (vars.malicious_score.split('-')[1] | int) %}{{\"Malicious\"}}{% elif vars.steps.Get_Reputation.data.results[0].score > (vars.suspicious_score.split('-')[1] | int) %}{{\"Suspicious\"}}{% elif vars.steps.Get_Reputation.data.results[0].score > (vars.good_score.split('-')[1] | int) %}{{\"Good\"}}{% else %}{{\"No Reputation Available\"}}{% endif %}",
+                "verdict": "{% if vars.steps.Get_Reputation_Hash.data.results[0].score > (vars.malicious_score.split('-')[1] | int) %}{{\"Malicious\"}}{% elif vars.steps.Get_Reputation_Hash.data.results[0].score > (vars.suspicious_score.split('-')[1] | int) %}{{\"Suspicious\"}}{% elif vars.steps.Get_Reputation_Hash.data.results[0].score > (vars.good_score.split('-')[1] | int) %}{{\"Good\"}}{% else %}{{\"No Reputation Available\"}}{% endif %}",
                 "cti_name": "CywareCTIX",
-                "cti_score": "{{vars.steps.Get_Reputation.data.results[0].score}}",
-                "source_data": "{\"CywareCTIX\": {{vars.steps.Get_Reputation.data}} }",
+                "cti_score": "{{vars.steps.Get_Reputation_Hash.data.results[0].score}}",
+                "source_data": "{\"CywareCTIX\": {{vars.steps.Get_Reputation_Hash.data}} }",
                 "enrichment_summary": "{{vars.steps.Compute_Enrichment_Summary.data['formatted_string']}}"
               },
               "status": null,
-              "top": "700",
-              "left": "480",
+              "top": "705",
+              "left": "125",
               "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
               "group": null,
               "uuid": "964b9651-4c36-4f30-8832-bd65f0b168ad"
@@ -143,57 +383,48 @@
               "stepType": "/api/3/workflow_step_types/b348f017-9a94-471f-87f8-ce88b6a7ad62",
               "group": null,
               "uuid": "9ddf2208-ce2f-466b-bcfb-cbdde2851747"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "No Operation",
-              "description": null,
-              "arguments": {
-                "params": [],
-                "version": "3.2.3",
-                "connector": "cyops_utilities",
-                "operation": "no_op",
-                "operationTitle": "Utils: No Operation",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "570",
-              "left": "125",
-              "stepType": "/api/3/workflow_step_types/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-              "group": null,
-              "uuid": "f592bdc6-c846-4029-95ac-5d8558f13c00"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Compute Enrichment Summary",
-              "description": null,
-              "arguments": {
-                "params": {
-                  "value": "<table class=\"no-border\">\n    <tr>\n        <th colspan=\"5\" class=\"no-background padding-0\">\n            <div class=\"font-size-11 ng-binding padding-bottom-sm\">\n                <h4 style=\"color: orange;\"\n                    class=\"body-default-bgcolor margin-bottom-0 padding-bottom-md padding-left-md padding-top-md text-align-left\">\n                    Cyware CTIX Detection Summary</h4>\n            </div>\n        </th>\n    </tr>\n    <tr class=\"solid-border\">\n        <td>\n            <div small class=\"control-label\">Score</div>\n            <div class=\"card-container-body margin-left-0\" style=\"width: 100px;\">\n                <div>{% if vars.steps.Get_Reputation.data.results[0].score > (vars.malicious_score.split('-')[1] | int) %}</div>\n                <div class=\"body-default-bgcolor card-number padding-left-md\"\n                    style=\"border-left: 5px solid {{vars.input.params.style_colors.Malicious}};padding: 11px;font-size: 18px !important;\">\n                    {{vars.steps.Get_Reputation.data.results[0].score}}</div>\n                <div>{% elif vars.steps.Get_Reputation.data.results[0].score > (vars.suspicious_score.split('-')[1] | int) %}</div>\n                <div class=\"body-default-bgcolor card-number padding-left-md\"\n                    style=\"border-left: 5px solid {{vars.input.params.style_colors.Suspicious}};padding: 11px;font-size: 18px !important;\">\n                    {{vars.steps.Get_Reputation.data.results[0].score}}</div>\n                <div>{% elif vars.steps.Get_Reputation.data.results[0].score > (vars.good_score.split('-')[1] | int) %}</div>\n                <div class=\"body-default-bgcolor card-number padding-left-md\"\n                    style=\"border-left: 5px solid {{vars.input.params.style_colors.Good}};padding: 11px;font-size: 18px !important;\">\n                    {{vars.steps.Get_Reputation.data.results[0].score}}</div>\n                <div>{% else %}</div>\n                <div class=\"body-default-bgcolor card-number padding-left-md\"\n                    style=\"border-left: 5px solid {{vars.input.params.style_colors['No Reputation Available']}};padding: 11px;font-size: 18px !important;\">\n                    {{vars.steps.Get_Reputation.data.results[0].score}}</div>\n                <div>{% endif %}</div>\n            </div>\n        </td>\n    </tr>\n</table>"
-                },
-                "version": "3.2.3",
-                "connector": "cyops_utilities",
-                "operation": "format_richtext",
-                "operationTitle": "Utils: Format as RichText (Markdown)",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "560",
-              "left": "480",
-              "stepType": "/api/3/workflow_step_types/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-              "group": null,
-              "uuid": "f5ff3c32-df71-4e70-a7de-31110e8164e6"
             }
           ],
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "name": "Configuration -> Get Reputation2",
-              "targetStep": "/api/3/workflow_steps/034cb284-84e7-4946-8153-a44200d13284",
+              "name": "Compute Enrichment Summary -> Return Output Data",
+              "targetStep": "/api/3/workflow_steps/964b9651-4c36-4f30-8832-bd65f0b168ad",
+              "sourceStep": "/api/3/workflow_steps/f5ff3c32-df71-4e70-a7de-31110e8164e6",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "f64aa714-1185-4af7-938d-264a74fe0c87"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Configuration -> Get Reputation",
+              "targetStep": "/api/3/workflow_steps/d66ba611-1e8c-460a-a81d-1e167357affc",
               "sourceStep": "/api/3/workflow_steps/0d6e08c5-6a41-445e-8cbf-0a5d6d014eb4",
               "label": null,
               "isExecuted": false,
-              "uuid": "5e32d9c6-c7b8-4616-8552-20f3064a1fe6"
+              "group": null,
+              "uuid": "93aa9259-6492-48d1-be13-262d2870372a"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Get Reputation -> Is Reputation Found",
+              "targetStep": "/api/3/workflow_steps/9015263f-fd19-4b27-a8b3-06eccb7d2e2e",
+              "sourceStep": "/api/3/workflow_steps/d66ba611-1e8c-460a-a81d-1e167357affc",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "8091efc8-083b-48f4-b625-1a95dbe94c23"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Is Reputation Found -> Compute Enrichment Summary",
+              "targetStep": "/api/3/workflow_steps/f5ff3c32-df71-4e70-a7de-31110e8164e6",
+              "sourceStep": "/api/3/workflow_steps/9015263f-fd19-4b27-a8b3-06eccb7d2e2e",
+              "label": "Yes",
+              "isExecuted": false,
+              "group": null,
+              "uuid": "57b59266-4798-40c5-968f-69285622dec6"
             },
             {
               "@type": "WorkflowRoute",
@@ -202,6 +433,7 @@
               "sourceStep": "/api/3/workflow_steps/9015263f-fd19-4b27-a8b3-06eccb7d2e2e",
               "label": "No",
               "isExecuted": false,
+              "group": null,
               "uuid": "d9e01b78-d149-4c77-9a18-67029d0b4aba"
             },
             {
@@ -211,40 +443,16 @@
               "sourceStep": "/api/3/workflow_steps/9ddf2208-ce2f-466b-bcfb-cbdde2851747",
               "label": null,
               "isExecuted": false,
+              "group": null,
               "uuid": "8db7f57e-9824-4688-a6a5-0605ce03f56a"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Compute Enrichment Summary -> Return Output Data",
-              "targetStep": "/api/3/workflow_steps/964b9651-4c36-4f30-8832-bd65f0b168ad",
-              "sourceStep": "/api/3/workflow_steps/f5ff3c32-df71-4e70-a7de-31110e8164e6",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "f64aa714-1185-4af7-938d-264a74fe0c87"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Is Reputation Found -> Compute Enrichment Summary",
-              "targetStep": "/api/3/workflow_steps/f5ff3c32-df71-4e70-a7de-31110e8164e6",
-              "sourceStep": "/api/3/workflow_steps/9015263f-fd19-4b27-a8b3-06eccb7d2e2e",
-              "label": "Yes",
-              "isExecuted": false,
-              "uuid": "57b59266-4798-40c5-968f-69285622dec6"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Get Reputation2 -> Is Reputation Found",
-              "targetStep": "/api/3/workflow_steps/9015263f-fd19-4b27-a8b3-06eccb7d2e2e",
-              "sourceStep": "/api/3/workflow_steps/034cb284-84e7-4946-8153-a44200d13284",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "97e46aa5-555a-4548-b3bf-1d34999997b1"
             }
           ],
           "groups": [],
           "priority": "/api/3/picklists/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
           "uuid": "0df89390-f711-4444-84c5-7036f187ca8b",
-          "id": 3709,
+          "id": 3207,
           "owners": [],
           "isPrivate": false,
           "deletedAt": null,
@@ -253,6 +461,104 @@
             "Cyware",
             "cyware-ctix",
             "FileHash_Enrichment"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Get Enrichment Object Details",
+          "aliasName": null,
+          "tag": "#Cyware CTIX",
+          "description": "Retrieves the enrichment data for the given object and tool ID.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": null,
+          "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/58131ae5-efdc-4af8-ae64-8fe1ad418271",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Get Enrichment Object Details",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "''",
+                "params": {
+                  "toolID": "",
+                  "objectID": "",
+                  "object_type": ""
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "get_enrichment_object_details",
+                "operationTitle": "Get Enrichment Object Details",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "120",
+              "left": "188",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "fb0a3c58-87f8-4743-a181-066f75d3d628"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "29154edb-7d57-4c5c-9ce8-3da1d2ab0602",
+                "title": "Cyware CTIX: Get Enrichment Object Details",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "58131ae5-efdc-4af8-ae64-8fe1ad418271"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start-> Get Enrichment Object Details",
+              "targetStep": "/api/3/workflow_steps/fb0a3c58-87f8-4743-a181-066f75d3d628",
+              "sourceStep": "/api/3/workflow_steps/58131ae5-efdc-4af8-ae64-8fe1ad418271",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "ac5ba736-be1d-494a-9c05-e03a0aa487ec"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "1144dfef-ea89-4019-8b42-e9f69c4998a8",
+          "id": 3232,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "Cyware",
+            "cyware-ctix"
           ]
         },
         {
@@ -268,11 +574,36 @@
           "remoteExecutableFlag": false,
           "parameters": [],
           "synchronous": false,
-          "lastModifyDate": null,
+          "lastModifyDate": 1760347122,
           "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
           "versions": [],
           "triggerStep": "/api/3/workflow_steps/a53cf4af-c65b-4a8e-bb75-53ab8055144b",
           "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Search IP",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "98dc98c3-f61d-4268-a31e-3c54ae8f051a",
+                "params": {
+                  "ip": "{{}}",
+                  "page_size": ""
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "search_ip",
+                "operationTitle": "Search IP",
+                "pickFromTenant": false,
+                "step_variables": []
+              },
+              "status": null,
+              "top": "229",
+              "left": "369",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "fc060e56-6e44-4dc4-94db-f98b40f06791"
+            },
             {
               "@type": "WorkflowStep",
               "name": "Start",
@@ -299,49 +630,226 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
               "group": null,
               "uuid": "a53cf4af-c65b-4a8e-bb75-53ab8055144b"
-            },
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start -> Search IP",
+              "targetStep": "/api/3/workflow_steps/fc060e56-6e44-4dc4-94db-f98b40f06791",
+              "sourceStep": "/api/3/workflow_steps/a53cf4af-c65b-4a8e-bb75-53ab8055144b",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "6ebcad6a-de7e-4323-918d-d0790413cabf"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "15476a84-48b7-4021-8f22-722e9b5b009c",
+          "id": 3208,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "Cyware",
+            "cyware-ctix"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Create Intel via Open API",
+          "aliasName": null,
+          "tag": "#Cyware CTIX",
+          "description": "Create intel with additional details such as the source and collection. You can also include details for each object, such as description, notes, custom attributes, and more.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": null,
+          "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/12b33eb8-d935-4c37-b748-670cff917010",
+          "steps": [
             {
               "@type": "WorkflowStep",
-              "name": "Search IP",
+              "name": "Create Intel via Open API",
               "description": null,
               "arguments": {
                 "name": "Cyware CTIX",
                 "config": "''",
                 "params": {
-                  "ip": "",
-                  "page_size": ""
+                  "title": "",
+                  "source": "Miscellaneous",
+                  "allSDOS": null,
+                  "metadata": null,
+                  "collection": "Free Text"
                 },
-                "version": "1.1.0",
+                "version": "2.0.0",
                 "connector": "cyware-ctix",
-                "operation": "search_ip",
-                "operationTitle": "Search IP",
-                "step_variables": {
-                  "output_data": "{{vars.result}}"
-                }
+                "operation": "create_intel_via_open_api",
+                "operationTitle": "Create Intel via Open API",
+                "step_variables": []
               },
               "status": null,
               "top": "120",
               "left": "188",
               "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
               "group": null,
-              "uuid": "fe665bca-761b-475a-9486-b84a1aec08f2"
+              "uuid": "461ccb1c-42b8-48e6-9819-f01cd3769d7d"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "22f1c19f-a216-4077-abd5-a96a42259f89",
+                "title": "Cyware CTIX: Create Intel via Open API",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "12b33eb8-d935-4c37-b748-670cff917010"
             }
           ],
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "name": "Start-> Search IP",
-              "targetStep": "/api/3/workflow_steps/fe665bca-761b-475a-9486-b84a1aec08f2",
-              "sourceStep": "/api/3/workflow_steps/a53cf4af-c65b-4a8e-bb75-53ab8055144b",
+              "name": "Start-> Create Intel via Open API",
+              "targetStep": "/api/3/workflow_steps/461ccb1c-42b8-48e6-9819-f01cd3769d7d",
+              "sourceStep": "/api/3/workflow_steps/12b33eb8-d935-4c37-b748-670cff917010",
               "label": null,
               "isExecuted": false,
-              "uuid": "db99d233-4b68-4fb7-ad3a-6f06dfb3c5e2"
+              "group": null,
+              "uuid": "445741ba-be9a-49c6-a0b6-31bab66b66e6"
             }
           ],
           "groups": [],
           "priority": null,
-          "uuid": "15476a84-48b7-4021-8f22-722e9b5b009c",
-          "id": 3696,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "17606a9b-6be1-401f-a781-599507eb0a21",
+          "id": 3217,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "Cyware",
+            "cyware-ctix"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Get Relations List of Threat Data Object",
+          "aliasName": null,
+          "tag": "#Cyware CTIX",
+          "description": "Retrieves the list of relations and the relation details of a threat data object.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": null,
+          "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/2f506458-448c-4d02-920f-36f85891b77a",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Get Relations List of Threat Data Object",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "''",
+                "params": {
+                  "page": 1,
+                  "sources": "",
+                  "objectID": "",
+                  "page_size": 10,
+                  "objectType": ""
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "list_relations_of_threat_data_object",
+                "operationTitle": "Get Relations List of Threat Data Object",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "120",
+              "left": "188",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "150dfde0-96dd-4968-be11-930e779ca424"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "c4ddb8fc-074d-4245-be48-2e45a30fe084",
+                "title": "Cyware CTIX: Get Relations List of Threat Data Object",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "2f506458-448c-4d02-920f-36f85891b77a"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start-> Get Relations List of Threat Data Object",
+              "targetStep": "/api/3/workflow_steps/150dfde0-96dd-4968-be11-930e779ca424",
+              "sourceStep": "/api/3/workflow_steps/2f506458-448c-4d02-920f-36f85891b77a",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "00e8ea2d-c2d6-407a-a711-e6b61bc587d1"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "1ffc2ed0-bca6-4da6-a837-14f759df8528",
+          "id": 3226,
           "owners": [],
           "isPrivate": false,
           "deletedAt": null,
@@ -367,11 +875,103 @@
             "style_colors"
           ],
           "synchronous": false,
-          "lastModifyDate": 1684219417,
+          "lastModifyDate": 1760346456,
           "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
           "versions": [],
           "triggerStep": "/api/3/workflow_steps/d2199649-2e83-40a8-ba32-27bc1946e818",
           "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Compute Enrichment Summary",
+              "description": null,
+              "arguments": {
+                "params": {
+                  "value": "<table class=\"no-border\">\n    <tr>\n        <th colspan=\"5\" class=\"no-background padding-0\">\n            <div class=\"font-size-11 ng-binding padding-bottom-sm\">\n                <h4 style=\"color: orange;\"\n                    class=\"body-default-bgcolor margin-bottom-0 padding-bottom-md padding-left-md padding-top-md text-align-left\">\n                    Cyware CTIX Detection Summary</h4>\n            </div>\n        </th>\n    </tr>\n    <tr class=\"solid-border\">\n        <td>\n            <div small class=\"control-label\">Score</div>\n            <div class=\"card-container-body margin-left-0\" style=\"width: 100px;\">\n                <div>{% if vars.steps.Get_Reputation_URL.data.result.score > (vars.malicious_score.split('-')[1] | int) %}</div>\n                <div class=\"body-default-bgcolor card-number padding-left-md\"\n                    style=\"border-left: 5px solid {{vars.input.params.style_colors.Malicious}};padding: 11px;font-size: 18px !important;\">\n                    {{vars.steps.Get_Reputation_URL.data.result.score}}</div>\n                <div>{% elif vars.steps.Get_Reputation_URL.data.result.score > (vars.suspicious_score.split('-')[1] | int) %}</div>\n                <div class=\"body-default-bgcolor card-number padding-left-md\"\n                    style=\"border-left: 5px solid {{vars.input.params.style_colors.Suspicious}};padding: 11px;font-size: 18px !important;\">\n                    {{vars.steps.Get_Reputation_URL.data.result.score}}</div>\n                <div>{% elif vars.steps.Get_Reputation_URL.data.result.score > (vars.good_score.split('-')[1] | int) %}</div>\n                <div class=\"body-default-bgcolor card-number padding-left-md\"\n                    style=\"border-left: 5px solid {{vars.input.params.style_colors.Good}};padding: 11px;font-size: 18px !important;\">\n                    {{vars.steps.Get_Reputation_URL.data.result.score}}</div>\n                <div>{% else %}</div>\n                <div class=\"body-default-bgcolor card-number padding-left-md\"\n                    style=\"border-left: 5px solid {{vars.input.params.style_colors['No Reputation Available']}};padding: 11px;font-size: 18px !important;\">\n                    {{vars.steps.Get_Reputation_URL.data.result.score}}</div>\n                <div>{% endif %}</div>\n            </div>\n        </td>\n    </tr>\n</table>"
+                },
+                "version": "3.2.3",
+                "connector": "cyops_utilities",
+                "operation": "format_richtext",
+                "operationTitle": "Utils: Format as RichText (Markdown)",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "570",
+              "left": "125",
+              "stepType": "/api/3/workflow_step_types/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+              "group": null,
+              "uuid": "1e7f72ee-c106-4881-b24d-53d642a29776"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Configuration",
+              "description": null,
+              "arguments": {
+                "good_score": "33-0",
+                "useMockOutput": "{{globalVars.Demo_mode}}",
+                "indicator_value": "{{vars.input.params['indicator_value']}}",
+                "malicious_score": "100-67",
+                "suspicious_score": "66-34"
+              },
+              "status": null,
+              "top": "165",
+              "left": "300",
+              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+              "group": null,
+              "uuid": "792eee3b-bf16-427a-a956-b755ccb55bc9"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Get Reputation",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "98dc98c3-f61d-4268-a31e-3c54ae8f051a",
+                "params": {
+                  "url": "{{vars.indicator_value}}",
+                  "page_size": ""
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "search_url",
+                "mock_result": "{\n    \"data\": {\n        \"message\": \"\",\n        \"result\": {\n            \"package_count\": \"\",\n            \"whois_domain_report\": \"\",\n            \"stix_object_id\": \"\",\n            \"domain_data\": \"https://demo_data.com\",\n            \"created\": \"\",\n            \"package_details\": [\n                {\n                    \"source_grading\": \"\",\n                    \"intl_grading\": \"\",\n                    \"package_timestamp\": \"\",\n                    \"package_id\": \"\",\n                    \"package_title\": \"\",\n                    \"source_name\": \"\",\n                    \"collection_name\": \"\"\n                }\n            ],\n            \"domain_tld_data\": \".\",\n            \"packages_list\": [],\n            \"updated\": \"\",\n            \"url_data\": [],\n            \"score\": 82\n        }\n    }\n}",
+                "operationTitle": "Search URL",
+                "pickFromTenant": false,
+                "step_variables": []
+              },
+              "status": null,
+              "top": "300",
+              "left": "300",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "adb3ce98-85a1-41cb-87cd-613356ca9826"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Is Reputation Found",
+              "description": null,
+              "arguments": {
+                "conditions": [
+                  {
+                    "option": "Yes",
+                    "step_iri": "/api/3/workflow_steps/1e7f72ee-c106-4881-b24d-53d642a29776",
+                    "condition": "{{ vars.steps.Get_Reputation_URL.data.result.score != null }}",
+                    "step_name": "Compute Enrichment Summary"
+                  },
+                  {
+                    "option": "No",
+                    "default": true,
+                    "step_iri": "/api/3/workflow_steps/09bc3022-9370-4b12-9126-9318adb4635c",
+                    "step_name": "No Operation"
+                  }
+                ]
+              },
+              "status": null,
+              "top": "435",
+              "left": "300",
+              "stepType": "/api/3/workflow_step_types/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+              "group": null,
+              "uuid": "d05f8274-b154-44e4-bcc5-e46e0afb300f"
+            },
             {
               "@type": "WorkflowStep",
               "name": "No Operation",
@@ -386,120 +986,28 @@
               },
               "status": null,
               "top": "570",
-              "left": "125",
+              "left": "475",
               "stepType": "/api/3/workflow_step_types/0109f35d-090b-4a2b-bd8a-94cbc3508562",
               "group": null,
               "uuid": "09bc3022-9370-4b12-9126-9318adb4635c"
             },
             {
               "@type": "WorkflowStep",
-              "name": "Compute Enrichment Summary",
-              "description": null,
-              "arguments": {
-                "params": {
-                  "value": "<table class=\"no-border\">\n    <tr>\n        <th colspan=\"5\" class=\"no-background padding-0\">\n            <div class=\"font-size-11 ng-binding padding-bottom-sm\">\n                <h4 style=\"color: orange;\"\n                    class=\"body-default-bgcolor margin-bottom-0 padding-bottom-md padding-left-md padding-top-md text-align-left\">\n                    Cyware CTIX Detection Summary</h4>\n            </div>\n        </th>\n    </tr>\n    <tr class=\"solid-border\">\n        <td>\n            <div small class=\"control-label\">Score</div>\n            <div class=\"card-container-body margin-left-0\" style=\"width: 100px;\">\n                <div>{% if vars.steps.Get_Reputation.data.result.score > (vars.malicious_score.split('-')[1] | int) %}</div>\n                <div class=\"body-default-bgcolor card-number padding-left-md\"\n                    style=\"border-left: 5px solid {{vars.input.params.style_colors.Malicious}};padding: 11px;font-size: 18px !important;\">\n                    {{vars.steps.Get_Reputation.data.result.score}}</div>\n                <div>{% elif vars.steps.Get_Reputation.data.result.score > (vars.suspicious_score.split('-')[1] | int) %}</div>\n                <div class=\"body-default-bgcolor card-number padding-left-md\"\n                    style=\"border-left: 5px solid {{vars.input.params.style_colors.Suspicious}};padding: 11px;font-size: 18px !important;\">\n                    {{vars.steps.Get_Reputation.data.result.score}}</div>\n                <div>{% elif vars.steps.Get_Reputation.data.result.score > (vars.good_score.split('-')[1] | int) %}</div>\n                <div class=\"body-default-bgcolor card-number padding-left-md\"\n                    style=\"border-left: 5px solid {{vars.input.params.style_colors.Good}};padding: 11px;font-size: 18px !important;\">\n                    {{vars.steps.Get_Reputation.data.result.score}}</div>\n                <div>{% else %}</div>\n                <div class=\"body-default-bgcolor card-number padding-left-md\"\n                    style=\"border-left: 5px solid {{vars.input.params.style_colors['No Reputation Available']}};padding: 11px;font-size: 18px !important;\">\n                    {{vars.steps.Get_Reputation.data.result.score}}</div>\n                <div>{% endif %}</div>\n            </div>\n        </td>\n    </tr>\n</table>"
-                },
-                "version": "3.2.3",
-                "connector": "cyops_utilities",
-                "operation": "format_richtext",
-                "operationTitle": "Utils: Format as RichText (Markdown)",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "560",
-              "left": "480",
-              "stepType": "/api/3/workflow_step_types/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-              "group": null,
-              "uuid": "1e7f72ee-c106-4881-b24d-53d642a29776"
-            },
-            {
-              "@type": "WorkflowStep",
               "name": "Return Output Data",
               "description": null,
               "arguments": {
-                "verdict": "{% if vars.steps.Get_Reputation.data.result.score > (vars.malicious_score.split('-')[1] | int) %}{{\"Malicious\"}}{% elif vars.steps.Get_Reputation.data.result.score > (vars.suspicious_score.split('-')[1] | int) %}{{\"Suspicious\"}}{% elif vars.steps.Get_Reputation.data.result.score > (vars.good_score.split('-')[1] | int) %}{{\"Good\"}}{% else %}{{\"No Reputation Available\"}}{% endif %}",
+                "verdict": "{% if vars.steps.Get_Reputation_URL.data.result.score > (vars.malicious_score.split('-')[1] | int) %}{{\"Malicious\"}}{% elif vars.steps.Get_Reputation_URL.data.result.score > (vars.suspicious_score.split('-')[1] | int) %}{{\"Suspicious\"}}{% elif vars.steps.Get_Reputation_URL.data.result.score > (vars.good_score.split('-')[1] | int) %}{{\"Good\"}}{% else %}{{\"No Reputation Available\"}}{% endif %}",
                 "cti_name": "CywareCTIX",
-                "cti_score": "{{vars.steps.Get_Reputation.data.result.score}}",
-                "source_data": "{\"CywareCTIX\": {{vars.steps.Get_Reputation.data}} }",
+                "cti_score": "{{vars.steps.Get_Reputation_URL.data.result.score}}",
+                "source_data": "{\"CywareCTIX\": {{vars.steps.Get_Reputation_URL.data}} }",
                 "enrichment_summary": "{{vars.steps.Compute_Enrichment_Summary.data['formatted_string']}}"
               },
               "status": null,
-              "top": "700",
-              "left": "480",
+              "top": "705",
+              "left": "125",
               "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
               "group": null,
               "uuid": "521b8b46-1125-4418-8370-445f7d70b279"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Configuration",
-              "description": null,
-              "arguments": {
-                "good_score": "33-0",
-                "useMockOutput": "{{globalVars.Demo_mode}}",
-                "indicator_value": "{{vars.input.params['indicator_value']}}",
-                "malicious_score": "100-67",
-                "suspicious_score": "66-34"
-              },
-              "status": null,
-              "top": "160",
-              "left": "300",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "group": null,
-              "uuid": "792eee3b-bf16-427a-a956-b755ccb55bc9"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Reputation",
-              "description": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "31319c16-be23-43d3-9e71-6d4abbbbf644",
-                "params": {
-                  "url": "{{vars.indicator_value}}",
-                  "page_size": ""
-                },
-                "version": "1.1.0",
-                "connector": "cyware-ctix",
-                "operation": "search_url",
-                "mock_result": "{\n    \"data\": {\n        \"message\": \"\",\n        \"result\": {\n            \"package_count\": \"\",\n            \"whois_domain_report\": \"\",\n            \"stix_object_id\": \"\",\n            \"domain_data\": \"https://demo_data.com\",\n            \"created\": \"\",\n            \"package_details\": [\n                {\n                    \"source_grading\": \"\",\n                    \"intl_grading\": \"\",\n                    \"package_timestamp\": \"\",\n                    \"package_id\": \"\",\n                    \"package_title\": \"\",\n                    \"source_name\": \"\",\n                    \"collection_name\": \"\"\n                }\n            ],\n            \"domain_tld_data\": \".\",\n            \"packages_list\": [],\n            \"updated\": \"\",\n            \"url_data\": [],\n            \"score\": 82\n        }\n    }\n}",
-                "operationTitle": "Search URL",
-                "pickFromTenant": false,
-                "step_variables": []
-              },
-              "status": null,
-              "top": "300",
-              "left": "300",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "c3fb6645-f2ef-4ca4-b0fb-713995b271d6"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Is Reputation Found",
-              "description": null,
-              "arguments": {
-                "conditions": [
-                  {
-                    "option": "Yes",
-                    "step_iri": "/api/3/workflow_steps/1e7f72ee-c106-4881-b24d-53d642a29776",
-                    "condition": "{{ vars.steps.Get_Reputation.data.result.score != null }}",
-                    "step_name": "Compute Enrichment Summary"
-                  },
-                  {
-                    "option": "No",
-                    "default": true,
-                    "step_iri": "/api/3/workflow_steps/09bc3022-9370-4b12-9126-9318adb4635c",
-                    "step_name": "No Operation"
-                  }
-                ]
-              },
-              "status": null,
-              "top": "440",
-              "left": "300",
-              "stepType": "/api/3/workflow_step_types/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-              "group": null,
-              "uuid": "d05f8274-b154-44e4-bcc5-e46e0afb300f"
             },
             {
               "@type": "WorkflowStep",
@@ -523,12 +1031,43 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "name": "Configuration -> Get Reputation2",
-              "targetStep": "/api/3/workflow_steps/c3fb6645-f2ef-4ca4-b0fb-713995b271d6",
+              "name": "Compute Enrichment Summary -> Return Output Data",
+              "targetStep": "/api/3/workflow_steps/521b8b46-1125-4418-8370-445f7d70b279",
+              "sourceStep": "/api/3/workflow_steps/1e7f72ee-c106-4881-b24d-53d642a29776",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "c2a9e673-cbe2-476f-b3cf-66c5e7b44ade"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Configuration -> Get Reputation",
+              "targetStep": "/api/3/workflow_steps/adb3ce98-85a1-41cb-87cd-613356ca9826",
               "sourceStep": "/api/3/workflow_steps/792eee3b-bf16-427a-a956-b755ccb55bc9",
               "label": null,
               "isExecuted": false,
-              "uuid": "08f792c0-d588-49f7-8806-1f1355852e4e"
+              "group": null,
+              "uuid": "15120cb3-f4b3-44b0-8251-676abb93e4a3"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Get Reputation -> Is Reputation Found",
+              "targetStep": "/api/3/workflow_steps/d05f8274-b154-44e4-bcc5-e46e0afb300f",
+              "sourceStep": "/api/3/workflow_steps/adb3ce98-85a1-41cb-87cd-613356ca9826",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "bcdf00e4-24ab-4884-8304-314789b64cd7"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Is Reputation Found -> Compute Enrichment Summary",
+              "targetStep": "/api/3/workflow_steps/1e7f72ee-c106-4881-b24d-53d642a29776",
+              "sourceStep": "/api/3/workflow_steps/d05f8274-b154-44e4-bcc5-e46e0afb300f",
+              "label": "Yes",
+              "isExecuted": false,
+              "group": null,
+              "uuid": "9a185d56-bb72-46d5-91a3-b22a2cba80e9"
             },
             {
               "@type": "WorkflowRoute",
@@ -537,6 +1076,7 @@
               "sourceStep": "/api/3/workflow_steps/d05f8274-b154-44e4-bcc5-e46e0afb300f",
               "label": "No",
               "isExecuted": false,
+              "group": null,
               "uuid": "1643a1d6-5879-4534-99e3-912e36ce0501"
             },
             {
@@ -546,46 +1086,122 @@
               "sourceStep": "/api/3/workflow_steps/d2199649-2e83-40a8-ba32-27bc1946e818",
               "label": null,
               "isExecuted": false,
+              "group": null,
               "uuid": "d8ab4cc3-3927-405f-ad4c-0deb99034479"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Compute Enrichment Summary -> Return Output Data",
-              "targetStep": "/api/3/workflow_steps/521b8b46-1125-4418-8370-445f7d70b279",
-              "sourceStep": "/api/3/workflow_steps/1e7f72ee-c106-4881-b24d-53d642a29776",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "c2a9e673-cbe2-476f-b3cf-66c5e7b44ade"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Is Reputation Found -> Compute Enrichment Summary",
-              "targetStep": "/api/3/workflow_steps/1e7f72ee-c106-4881-b24d-53d642a29776",
-              "sourceStep": "/api/3/workflow_steps/d05f8274-b154-44e4-bcc5-e46e0afb300f",
-              "label": "Yes",
-              "isExecuted": false,
-              "uuid": "9a185d56-bb72-46d5-91a3-b22a2cba80e9"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Get Reputation2 -> Is Reputation Found",
-              "targetStep": "/api/3/workflow_steps/d05f8274-b154-44e4-bcc5-e46e0afb300f",
-              "sourceStep": "/api/3/workflow_steps/c3fb6645-f2ef-4ca4-b0fb-713995b271d6",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "5ec4daec-9335-47cf-bfb9-999e129b9670"
             }
           ],
           "groups": [],
           "priority": "/api/3/picklists/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
           "uuid": "2180a862-d26f-4019-ba12-0b263da85421",
-          "id": 3707,
+          "id": 3209,
           "owners": [],
           "isPrivate": false,
           "deletedAt": null,
           "importedBy": [],
           "recordTags": [
-            "URL_Enrichment",
+            "Cyware",
+            "cyware-ctix",
+            "URL_Enrichment"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Get Enriched Threat Data",
+          "aliasName": null,
+          "tag": "#Cyware CTIX",
+          "description": "Returns the enriched data of a threat data object using enrichment tools.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": null,
+          "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/d979691a-38e1-4c97-9367-d3a15678b336",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Get Enriched Threat Data",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "''",
+                "params": {
+                  "value": "",
+                  "app_slug": "",
+                  "objectID": "",
+                  "action_slug": "",
+                  "object_type": ""
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "get_enriched_threat_data",
+                "operationTitle": "Get Enriched Threat Data",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "120",
+              "left": "188",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "da28f12e-0553-4073-9398-ff3b54b66cd7"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "d3a5138d-208c-4105-9f89-0962cd79619b",
+                "title": "Cyware CTIX: Get Enriched Threat Data",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "d979691a-38e1-4c97-9367-d3a15678b336"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start-> Get Enriched Threat Data",
+              "targetStep": "/api/3/workflow_steps/da28f12e-0553-4073-9398-ff3b54b66cd7",
+              "sourceStep": "/api/3/workflow_steps/d979691a-38e1-4c97-9367-d3a15678b336",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "10cccc6b-df48-4c0d-9708-0a9db9bcc490"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "294a2d19-515a-4f01-b276-0b57a3837341",
+          "id": 3233,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
             "Cyware",
             "cyware-ctix"
           ]
@@ -603,7 +1219,7 @@
           "remoteExecutableFlag": false,
           "parameters": [],
           "synchronous": false,
-          "lastModifyDate": null,
+          "lastModifyDate": 1760347158,
           "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
           "versions": [],
           "triggerStep": "/api/3/workflow_steps/f8de693d-3e8f-4d30-9399-c73b2f2efb3c",
@@ -614,25 +1230,24 @@
               "description": null,
               "arguments": {
                 "name": "Cyware CTIX",
-                "config": "''",
+                "config": "98dc98c3-f61d-4268-a31e-3c54ae8f051a",
                 "params": {
-                  "url": "",
+                  "url": "{{}}",
                   "page_size": ""
                 },
-                "version": "1.1.0",
+                "version": "2.0.0",
                 "connector": "cyware-ctix",
                 "operation": "search_url",
                 "operationTitle": "Search URL",
-                "step_variables": {
-                  "output_data": "{{vars.result}}"
-                }
+                "pickFromTenant": false,
+                "step_variables": []
               },
               "status": null,
-              "top": "120",
-              "left": "188",
+              "top": "275",
+              "left": "397",
               "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
               "group": null,
-              "uuid": "13df22fc-1aab-4da9-b6b6-a1e3d332f5b8"
+              "uuid": "86698152-13f0-44e1-8de1-1fc97f2fc0d2"
             },
             {
               "@type": "WorkflowStep",
@@ -665,18 +1280,220 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "name": "Start-> Search URL",
-              "targetStep": "/api/3/workflow_steps/13df22fc-1aab-4da9-b6b6-a1e3d332f5b8",
+              "name": "Start -> Search URL",
+              "targetStep": "/api/3/workflow_steps/86698152-13f0-44e1-8de1-1fc97f2fc0d2",
               "sourceStep": "/api/3/workflow_steps/f8de693d-3e8f-4d30-9399-c73b2f2efb3c",
               "label": null,
               "isExecuted": false,
-              "uuid": "d39e61a3-d944-4230-a4c7-05ddb39935ab"
+              "group": null,
+              "uuid": "3015f952-d98d-437f-b8d1-7dc55dbe320f"
             }
           ],
           "groups": [],
           "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
           "uuid": "309543ef-670f-4b44-8a8e-604a88741849",
-          "id": 3697,
+          "id": 3210,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "Cyware",
+            "cyware-ctix"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Run Report",
+          "aliasName": null,
+          "tag": "#Cyware CTIX",
+          "description": "Runs a report and sends the file to the recipients",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": null,
+          "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/6484dad8-6d99-452b-be98-da868bdf92b5",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Run Report",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "''",
+                "params": {
+                  "type": "basic",
+                  "end_time": "",
+                  "report_id": "",
+                  "file_types": "",
+                  "start_time": "",
+                  "external_recipients": [],
+                  "internal_recipients": []
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "run_report",
+                "operationTitle": "Run Report",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "120",
+              "left": "188",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "70195abc-dffc-42f9-a697-f3dc53012c20"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "c8fc8006-a853-4dc4-84b6-230e9300f4a6",
+                "title": "Cyware CTIX: Run Report",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "6484dad8-6d99-452b-be98-da868bdf92b5"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start-> Run Report",
+              "targetStep": "/api/3/workflow_steps/70195abc-dffc-42f9-a697-f3dc53012c20",
+              "sourceStep": "/api/3/workflow_steps/6484dad8-6d99-452b-be98-da868bdf92b5",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "36ec5d54-5997-4eb2-a110-ecf7d77e1082"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "31ebf40d-51c5-42f6-8842-8a29e400554c",
+          "id": 3241,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "Cyware",
+            "cyware-ctix"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Create Tag",
+          "aliasName": null,
+          "tag": "#Cyware CTIX",
+          "description": "Creates a tag in the CTIX platform",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": null,
+          "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/2ef8a1a6-6003-4a8d-88b4-1d7750e2f54c",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Create Tag",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "''",
+                "params": {
+                  "name": "",
+                  "colour_code": null
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "create_tag",
+                "operationTitle": "Create Tag",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "120",
+              "left": "188",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "65ae4074-0539-4fde-b8e7-ff0b6c11b161"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "abfecd99-8498-4ca8-8b24-397218b0ed4f",
+                "title": "Cyware CTIX: Create Tag",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "2ef8a1a6-6003-4a8d-88b4-1d7750e2f54c"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start-> Create Tag",
+              "targetStep": "/api/3/workflow_steps/65ae4074-0539-4fde-b8e7-ff0b6c11b161",
+              "sourceStep": "/api/3/workflow_steps/2ef8a1a6-6003-4a8d-88b4-1d7750e2f54c",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "f672d2b9-f080-4991-892d-f30168e9c2b4"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "3ae5a416-301d-4f16-991a-0c995eda3834",
+          "id": 3235,
           "owners": [],
           "isPrivate": false,
           "deletedAt": null,
@@ -699,7 +1516,7 @@
           "remoteExecutableFlag": false,
           "parameters": [],
           "synchronous": false,
-          "lastModifyDate": null,
+          "lastModifyDate": 1760346989,
           "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
           "versions": [],
           "triggerStep": "/api/3/workflow_steps/a2604dfd-eacd-4dc0-801e-987623b23114",
@@ -710,25 +1527,24 @@
               "description": null,
               "arguments": {
                 "name": "Cyware CTIX",
-                "config": "''",
+                "config": "98dc98c3-f61d-4268-a31e-3c54ae8f051a",
                 "params": {
-                  "cve_id": "",
+                  "cve_id": "{{}}",
                   "page_size": ""
                 },
-                "version": "1.1.0",
+                "version": "2.0.0",
                 "connector": "cyware-ctix",
                 "operation": "search_cve_id",
                 "operationTitle": "Search CVE ID",
-                "step_variables": {
-                  "output_data": "{{vars.result}}"
-                }
+                "pickFromTenant": false,
+                "step_variables": []
               },
               "status": null,
-              "top": "120",
-              "left": "188",
+              "top": "165",
+              "left": "125",
               "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
               "group": null,
-              "uuid": "920ea3cc-c888-4b17-bd47-b9ca880dbffa"
+              "uuid": "5f90b7bd-e7e5-4307-a7a4-f479c5291218"
             },
             {
               "@type": "WorkflowStep",
@@ -751,8 +1567,8 @@
                 "singleRecordExecution": false
               },
               "status": null,
-              "top": "20",
-              "left": "20",
+              "top": "30",
+              "left": "125",
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
               "group": null,
               "uuid": "a2604dfd-eacd-4dc0-801e-987623b23114"
@@ -761,18 +1577,21 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "name": "Start-> Search CVE ID",
-              "targetStep": "/api/3/workflow_steps/920ea3cc-c888-4b17-bd47-b9ca880dbffa",
+              "name": "Start -> Search CVE ID",
+              "targetStep": "/api/3/workflow_steps/5f90b7bd-e7e5-4307-a7a4-f479c5291218",
               "sourceStep": "/api/3/workflow_steps/a2604dfd-eacd-4dc0-801e-987623b23114",
               "label": null,
               "isExecuted": false,
-              "uuid": "6b174767-ed19-47c7-9ee0-2ab3d822c67b"
+              "group": null,
+              "uuid": "81f06a24-00e9-4bcc-880a-fce66202b59c"
             }
           ],
           "groups": [],
           "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
           "uuid": "43235f89-d8b7-4557-b7f3-9d89ba9d9eaa",
-          "id": 3698,
+          "id": 3211,
           "owners": [],
           "isPrivate": false,
           "deletedAt": null,
@@ -785,7 +1604,206 @@
         {
           "@type": "Workflow",
           "triggerLimit": null,
-          "name": "Bulk Lookup and Create",
+          "name": "Get Threat Data",
+          "aliasName": null,
+          "tag": "#Cyware CTIX",
+          "description": "Returns a list of threat data objects from the CTIX application. You can retrieve a maximum of 500,000 threat data objects using this API.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": null,
+          "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/e8182d84-23fb-49d2-b3a5-e4e667805317",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Get Threat Data",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "''",
+                "params": {
+                  "page": 1,
+                  "sort": "-ctix_created",
+                  "query": "",
+                  "page_size": 1,
+                  "enrichment": true,
+                  "page_limit": 10
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "list_threat_data",
+                "operationTitle": "Get Threat Data",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "120",
+              "left": "188",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "c991224a-d8e6-4e8a-899a-1d19a6c044ed"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "e49302c6-1cd1-4a54-aa89-102f0ba20270",
+                "title": "Cyware CTIX: Get Threat Data",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "e8182d84-23fb-49d2-b3a5-e4e667805317"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start-> Get Threat Data",
+              "targetStep": "/api/3/workflow_steps/c991224a-d8e6-4e8a-899a-1d19a6c044ed",
+              "sourceStep": "/api/3/workflow_steps/e8182d84-23fb-49d2-b3a5-e4e667805317",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "7d30aec0-7b39-4a1a-88ea-2c4fdb5c28b7"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "462fc98e-a501-458d-aa48-82ced1c04cbb",
+          "id": 3218,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "Cyware",
+            "cyware-ctix"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Bulk Mark/Unmark False Positive",
+          "aliasName": null,
+          "tag": "#Cyware CTIX",
+          "description": "Mark or unmark multiple IOCs as false positives.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": null,
+          "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/30676854-1901-4644-8a7d-de9d42082c51",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Bulk Mark/Unmark False Positive",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "''",
+                "params": {
+                  "object_ids": "",
+                  "action_type": "false_positive",
+                  "object_type": ""
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "bulk_mark_unmark_false_positive",
+                "operationTitle": "Bulk Mark/Unmark False Positive",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "120",
+              "left": "188",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "406df572-71ac-45c2-9b56-3456019fce42"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "e6501d7e-f80b-4216-a1e0-5a56cf640ecc",
+                "title": "Cyware CTIX: Bulk Mark/Unmark False Positive",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "30676854-1901-4644-8a7d-de9d42082c51"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start-> Bulk Mark/Unmark False Positive",
+              "targetStep": "/api/3/workflow_steps/406df572-71ac-45c2-9b56-3456019fce42",
+              "sourceStep": "/api/3/workflow_steps/30676854-1901-4644-8a7d-de9d42082c51",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "216e2b38-34c0-4d65-b380-56b61fce5ab2"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "4d5d3dd3-4a53-4b15-9c48-c66a83413369",
+          "id": 3221,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "Cyware",
+            "cyware-ctix"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Bulk Lookup and Create (Deprecated)",
           "aliasName": null,
           "tag": "#Cyware CTIX",
           "description": "This API fetches the list of threat data objects present in the CTIX application. In case some IOCs are not present in the application, you can choose to ingest the missing IOCs and create new records. You can lookup and further ingest a maximum of 1000 IOCs in the application at any moment.",
@@ -795,7 +1813,7 @@
           "remoteExecutableFlag": false,
           "parameters": [],
           "synchronous": false,
-          "lastModifyDate": null,
+          "lastModifyDate": 1760346752,
           "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
           "versions": [],
           "triggerStep": "/api/3/workflow_steps/671df1c1-76d0-40ba-b236-d458f43f2fde",
@@ -806,30 +1824,34 @@
               "description": null,
               "arguments": {
                 "name": "Cyware CTIX",
-                "config": "''",
+                "config": "98dc98c3-f61d-4268-a31e-3c54ae8f051a",
                 "params": {
+                  "create": "",
+                  "source": "",
                   "metadata": {
                     "tlp": "RED",
                     "tags": [
                       "Tagged"
                     ],
                     "confidence": 100
-                  }
+                  },
+                  "collection": "",
+                  "enrichment": "",
+                  "ioc_values": "{{}}"
                 },
-                "version": "1.1.0",
+                "version": "2.0.0",
                 "connector": "cyware-ctix",
                 "operation": "bulk_lookup_and_create",
-                "operationTitle": "Bulk Lookup and Create",
-                "step_variables": {
-                  "output_data": "{{vars.result}}"
-                }
+                "operationTitle": "Bulk Lookup and Create (Deprecated)",
+                "pickFromTenant": false,
+                "step_variables": []
               },
               "status": null,
-              "top": "120",
-              "left": "188",
+              "top": "197",
+              "left": "196",
               "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
               "group": null,
-              "uuid": "03253da7-b8aa-4a60-9d19-35e7b6020ae6"
+              "uuid": "1c61517e-09bb-4f22-b1e5-ceb025b80091"
             },
             {
               "@type": "WorkflowStep",
@@ -862,18 +1884,21 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "name": "Start-> Bulk Lookup and Create",
-              "targetStep": "/api/3/workflow_steps/03253da7-b8aa-4a60-9d19-35e7b6020ae6",
+              "name": "Start -> Bulk Lookup",
+              "targetStep": "/api/3/workflow_steps/1c61517e-09bb-4f22-b1e5-ceb025b80091",
               "sourceStep": "/api/3/workflow_steps/671df1c1-76d0-40ba-b236-d458f43f2fde",
               "label": null,
               "isExecuted": false,
-              "uuid": "6b5cd482-6301-4d94-8996-5ae39d82fd34"
+              "group": null,
+              "uuid": "317b945a-3306-41e7-a3d0-83f374e89ce9"
             }
           ],
           "groups": [],
           "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
           "uuid": "711ccf4b-f31b-4304-a423-70bffb3a8db4",
-          "id": 3699,
+          "id": 3212,
           "owners": [],
           "isPrivate": false,
           "deletedAt": null,
@@ -896,11 +1921,36 @@
           "remoteExecutableFlag": false,
           "parameters": [],
           "synchronous": false,
-          "lastModifyDate": 1683889994,
+          "lastModifyDate": 1760347066,
           "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
           "versions": [],
           "triggerStep": "/api/3/workflow_steps/188dfc82-84c9-4514-b77e-218483cc507d",
           "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Search Domain",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "98dc98c3-f61d-4268-a31e-3c54ae8f051a",
+                "params": {
+                  "domain": "{{}}",
+                  "page_size": ""
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "search_domain",
+                "operationTitle": "Search Domain",
+                "pickFromTenant": false,
+                "step_variables": []
+              },
+              "status": null,
+              "top": "202",
+              "left": "282",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "9daf05e9-dabf-4715-a776-23fa539438f5"
+            },
             {
               "@type": "WorkflowStep",
               "name": "Start",
@@ -922,54 +1972,31 @@
                 "singleRecordExecution": false
               },
               "status": null,
-              "top": "20",
-              "left": "20",
+              "top": "40",
+              "left": "40",
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
               "group": null,
               "uuid": "188dfc82-84c9-4514-b77e-218483cc507d"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Search Domain",
-              "description": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "31319c16-be23-43d3-9e71-6d4abbbbf644",
-                "params": {
-                  "domain": "dfgdfgv",
-                  "page_size": ""
-                },
-                "version": "1.1.0",
-                "connector": "cyware-ctix",
-                "operation": "search_domain",
-                "operationTitle": "Search Domain",
-                "step_variables": {
-                  "output_data": "{{vars.result}}"
-                }
-              },
-              "status": null,
-              "top": "120",
-              "left": "180",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "8248b9ec-b8aa-4259-9dc6-6052e68313b4"
             }
           ],
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "name": "Start-> Search Domain",
-              "targetStep": "/api/3/workflow_steps/8248b9ec-b8aa-4259-9dc6-6052e68313b4",
+              "name": "Start -> Search Domai",
+              "targetStep": "/api/3/workflow_steps/9daf05e9-dabf-4715-a776-23fa539438f5",
               "sourceStep": "/api/3/workflow_steps/188dfc82-84c9-4514-b77e-218483cc507d",
               "label": null,
               "isExecuted": false,
-              "uuid": "6f3115c8-9905-4c3a-94c0-d2716b86ae02"
+              "group": null,
+              "uuid": "0212cac1-018d-408c-9900-d1b47ec0f4e8"
             }
           ],
           "groups": [],
           "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
           "uuid": "7a0d63da-d448-448e-a3b9-0b51a08fa783",
-          "id": 3700,
+          "id": 3213,
           "owners": [],
           "isPrivate": false,
           "deletedAt": null,
@@ -995,92 +2022,11 @@
             "style_colors"
           ],
           "synchronous": false,
-          "lastModifyDate": 1684219461,
+          "lastModifyDate": 1760346526,
           "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
           "versions": [],
           "triggerStep": "/api/3/workflow_steps/699b45ff-e0c6-4911-af7f-1f19f2ef58f1",
           "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "No Operation",
-              "description": null,
-              "arguments": {
-                "params": [],
-                "version": "3.2.3",
-                "connector": "cyops_utilities",
-                "operation": "no_op",
-                "operationTitle": "Utils: No Operation",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "570",
-              "left": "125",
-              "stepType": "/api/3/workflow_step_types/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-              "group": null,
-              "uuid": "09bf3efa-bd68-4f99-921c-ef0a4b96d9b6"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Reputation",
-              "description": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "31319c16-be23-43d3-9e71-6d4abbbbf644",
-                "params": {
-                  "ip": "{{vars.indicator_value}}",
-                  "page_size": ""
-                },
-                "version": "1.1.0",
-                "connector": "cyware-ctix",
-                "operation": "search_ip",
-                "mock_result": "{\n  \"data\":{\n    \"message\":\"\",\n    \"result\":{\n      \"package_count\":\"\",\n      \"stix_object_id\":\"\",\n      \"ip_data\":\"1.1.1.1\",\n      \"maxmind_geoip_ip_report\":\"\",\n      \"geoip_report\":{\n        \"country\":{\n          \"country_code\":\"\",\n          \"country_name\":\"\"\n        },\n        \"city\":{\n          \"continent_name\":\"\",\n          \"country_code\":\"\",\n          \"city\":\"\",\n          \"latitude\":\"\",\n          \"country_name\":\"\",\n          \"dma_code\":null,\n          \"continent_code\":\"\",\n          \"postal_code\":\"\",\n          \"region\":\"\",\n          \"time_zone\":\"\",\n          \"longitude\":\"\"\n        }\n      },\n      \"created\":\"\",\n      \"whois_ip_report\":\"\",\n      \"package_details\":[\n        {\n          \"source_grading\":\"\",\n          \"intl_grading\":\"\",\n          \"package_timestamp\":\"\",\n          \"package_id\":\"\",\n          \"package_title\":\"\",\n          \"source_name\":\"\",\n          \"collection_name\":\"\"\n        }\n      ],\n      \"packages_list\":[\n        \n      ],\n      \"updated\":\"\",\n      \"score\":82\n    }\n  }\n}",
-                "operationTitle": "Search IP",
-                "pickFromTenant": false,
-                "step_variables": []
-              },
-              "status": null,
-              "top": "300",
-              "left": "300",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "5c07d703-2a6c-4d36-8c2b-a2b3a91c11d0"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "step_variables": {
-                  "input": {
-                    "params": []
-                  }
-                }
-              },
-              "status": null,
-              "top": "30",
-              "left": "300",
-              "stepType": "/api/3/workflow_step_types/b348f017-9a94-471f-87f8-ce88b6a7ad62",
-              "group": null,
-              "uuid": "699b45ff-e0c6-4911-af7f-1f19f2ef58f1"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Return Output Data",
-              "description": null,
-              "arguments": {
-                "verdict": "{% if vars.steps.Get_Reputation.data.result.score > (vars.malicious_score.split('-')[1] | int) %}{{\"Malicious\"}}{% elif vars.steps.Get_Reputation.data.result.score > (vars.suspicious_score.split('-')[1] | int) %}{{\"Suspicious\"}}{% elif vars.steps.Get_Reputation.data.result.score > (vars.good_score.split('-')[1] | int) %}{{\"Good\"}}{% else %}{{\"No Reputation Available\"}}{% endif %}",
-                "cti_name": "CywareCTIX",
-                "cti_score": "{{vars.steps.Get_Reputation.data.result.score}}",
-                "source_data": "{\"CywareCTIX\": {{vars.steps.Get_Reputation.data}} }",
-                "enrichment_summary": "{{vars.steps.Compute_Enrichment_Summary.data['formatted_string']}}"
-              },
-              "status": null,
-              "top": "700",
-              "left": "480",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "group": null,
-              "uuid": "93e21dd4-dca9-42fd-b9b5-1df4b4757ed3"
-            },
             {
               "@type": "WorkflowStep",
               "name": "Compute Enrichment Summary",
@@ -1101,6 +2047,50 @@
               "stepType": "/api/3/workflow_step_types/0109f35d-090b-4a2b-bd8a-94cbc3508562",
               "group": null,
               "uuid": "ae9c89eb-c9e9-4eb8-92ec-415a4a04b7c7"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Configuration",
+              "description": null,
+              "arguments": {
+                "good_score": "33-0",
+                "useMockOutput": "{{globalVars.Demo_mode}}",
+                "indicator_value": "{{vars.input.params['indicator_value']}}",
+                "malicious_score": "100-67",
+                "suspicious_score": "66-34"
+              },
+              "status": null,
+              "top": "160",
+              "left": "300",
+              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+              "group": null,
+              "uuid": "e4b85555-4dab-4a20-b027-858d1a154320"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Get Reputation",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "31319c16-be23-43d3-9e71-6d4abbbbf644",
+                "params": {
+                  "ip": "{{vars.indicator_value}}",
+                  "page_size": ""
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "search_ip",
+                "mock_result": "{\n  \"data\":{\n    \"message\":\"\",\n    \"result\":{\n      \"package_count\":\"\",\n      \"stix_object_id\":\"\",\n      \"ip_data\":\"1.1.1.1\",\n      \"maxmind_geoip_ip_report\":\"\",\n      \"geoip_report\":{\n        \"country\":{\n          \"country_code\":\"\",\n          \"country_name\":\"\"\n        },\n        \"city\":{\n          \"continent_name\":\"\",\n          \"country_code\":\"\",\n          \"city\":\"\",\n          \"latitude\":\"\",\n          \"country_name\":\"\",\n          \"dma_code\":null,\n          \"continent_code\":\"\",\n          \"postal_code\":\"\",\n          \"region\":\"\",\n          \"time_zone\":\"\",\n          \"longitude\":\"\"\n        }\n      },\n      \"created\":\"\",\n      \"whois_ip_report\":\"\",\n      \"package_details\":[\n        {\n          \"source_grading\":\"\",\n          \"intl_grading\":\"\",\n          \"package_timestamp\":\"\",\n          \"package_id\":\"\",\n          \"package_title\":\"\",\n          \"source_name\":\"\",\n          \"collection_name\":\"\"\n        }\n      ],\n      \"packages_list\":[\n        \n      ],\n      \"updated\":\"\",\n      \"score\":82\n    }\n  }\n}",
+                "operationTitle": "Search IP",
+                "pickFromTenant": false,
+                "step_variables": []
+              },
+              "status": null,
+              "top": "300",
+              "left": "300",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "5c07d703-2a6c-4d36-8c2b-a2b3a91c11d0"
             },
             {
               "@type": "WorkflowStep",
@@ -1131,24 +2121,71 @@
             },
             {
               "@type": "WorkflowStep",
-              "name": "Configuration",
+              "name": "No Operation",
               "description": null,
               "arguments": {
-                "good_score": "33-0",
-                "useMockOutput": "{{globalVars.Demo_mode}}",
-                "indicator_value": "{{vars.input.params['indicator_value']}}",
-                "malicious_score": "100-67",
-                "suspicious_score": "66-34"
+                "params": [],
+                "version": "3.2.3",
+                "connector": "cyops_utilities",
+                "operation": "no_op",
+                "operationTitle": "Utils: No Operation",
+                "step_variables": []
               },
               "status": null,
-              "top": "160",
-              "left": "300",
+              "top": "570",
+              "left": "125",
+              "stepType": "/api/3/workflow_step_types/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+              "group": null,
+              "uuid": "09bf3efa-bd68-4f99-921c-ef0a4b96d9b6"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Return Output Data",
+              "description": null,
+              "arguments": {
+                "verdict": "{% if vars.steps.Get_Reputation.data.result.score > (vars.malicious_score.split('-')[1] | int) %}{{\"Malicious\"}}{% elif vars.steps.Get_Reputation.data.result.score > (vars.suspicious_score.split('-')[1] | int) %}{{\"Suspicious\"}}{% elif vars.steps.Get_Reputation.data.result.score > (vars.good_score.split('-')[1] | int) %}{{\"Good\"}}{% else %}{{\"No Reputation Available\"}}{% endif %}",
+                "cti_name": "CywareCTIX",
+                "cti_score": "{{vars.steps.Get_Reputation.data.result.score}}",
+                "source_data": "{\"CywareCTIX\": {{vars.steps.Get_Reputation.data}} }",
+                "enrichment_summary": "{{vars.steps.Compute_Enrichment_Summary.data['formatted_string']}}"
+              },
+              "status": null,
+              "top": "700",
+              "left": "480",
               "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
               "group": null,
-              "uuid": "e4b85555-4dab-4a20-b027-858d1a154320"
+              "uuid": "93e21dd4-dca9-42fd-b9b5-1df4b4757ed3"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "step_variables": {
+                  "input": {
+                    "params": []
+                  }
+                }
+              },
+              "status": null,
+              "top": "30",
+              "left": "300",
+              "stepType": "/api/3/workflow_step_types/b348f017-9a94-471f-87f8-ce88b6a7ad62",
+              "group": null,
+              "uuid": "699b45ff-e0c6-4911-af7f-1f19f2ef58f1"
             }
           ],
           "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Compute Enrichment Summary -> Return Output Data",
+              "targetStep": "/api/3/workflow_steps/93e21dd4-dca9-42fd-b9b5-1df4b4757ed3",
+              "sourceStep": "/api/3/workflow_steps/ae9c89eb-c9e9-4eb8-92ec-415a4a04b7c7",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "b00d2e22-051f-4920-9134-1c2b4a0f83ae"
+            },
             {
               "@type": "WorkflowRoute",
               "name": "Configuration -> Get Reputation2",
@@ -1156,7 +2193,28 @@
               "sourceStep": "/api/3/workflow_steps/e4b85555-4dab-4a20-b027-858d1a154320",
               "label": null,
               "isExecuted": false,
+              "group": null,
               "uuid": "ab7e46be-e04e-443f-ba6d-2f1c36a6d738"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Get Reputation2 -> Is Reputation Found",
+              "targetStep": "/api/3/workflow_steps/b034ca3b-d64e-4f80-9e0a-40d4931b3d9e",
+              "sourceStep": "/api/3/workflow_steps/5c07d703-2a6c-4d36-8c2b-a2b3a91c11d0",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "01c994fc-2415-481c-9bea-32eed8bc449e"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Is Reputation Found -> Compute Enrichment Summary",
+              "targetStep": "/api/3/workflow_steps/ae9c89eb-c9e9-4eb8-92ec-415a4a04b7c7",
+              "sourceStep": "/api/3/workflow_steps/b034ca3b-d64e-4f80-9e0a-40d4931b3d9e",
+              "label": "Yes",
+              "isExecuted": false,
+              "group": null,
+              "uuid": "25a16e17-8538-4efa-84ad-e30f0ea35772"
             },
             {
               "@type": "WorkflowRoute",
@@ -1165,6 +2223,7 @@
               "sourceStep": "/api/3/workflow_steps/b034ca3b-d64e-4f80-9e0a-40d4931b3d9e",
               "label": "No",
               "isExecuted": false,
+              "group": null,
               "uuid": "bf3bcac4-6660-49cf-a89e-c53ffc3f040e"
             },
             {
@@ -1174,40 +2233,16 @@
               "sourceStep": "/api/3/workflow_steps/699b45ff-e0c6-4911-af7f-1f19f2ef58f1",
               "label": null,
               "isExecuted": false,
+              "group": null,
               "uuid": "bd1ac56e-1462-4a6a-82da-ba7ada70f980"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Compute Enrichment Summary -> Return Output Data",
-              "targetStep": "/api/3/workflow_steps/93e21dd4-dca9-42fd-b9b5-1df4b4757ed3",
-              "sourceStep": "/api/3/workflow_steps/ae9c89eb-c9e9-4eb8-92ec-415a4a04b7c7",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "b00d2e22-051f-4920-9134-1c2b4a0f83ae"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Is Reputation Found -> Compute Enrichment Summary",
-              "targetStep": "/api/3/workflow_steps/ae9c89eb-c9e9-4eb8-92ec-415a4a04b7c7",
-              "sourceStep": "/api/3/workflow_steps/b034ca3b-d64e-4f80-9e0a-40d4931b3d9e",
-              "label": "Yes",
-              "isExecuted": false,
-              "uuid": "25a16e17-8538-4efa-84ad-e30f0ea35772"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Get Reputation2 -> Is Reputation Found",
-              "targetStep": "/api/3/workflow_steps/b034ca3b-d64e-4f80-9e0a-40d4931b3d9e",
-              "sourceStep": "/api/3/workflow_steps/5c07d703-2a6c-4d36-8c2b-a2b3a91c11d0",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "01c994fc-2415-481c-9bea-32eed8bc449e"
             }
           ],
           "groups": [],
           "priority": "/api/3/picklists/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
           "uuid": "7d7b826e-052e-4590-b839-0842dff9063d",
-          "id": 3708,
+          "id": 3214,
           "owners": [],
           "isPrivate": false,
           "deletedAt": null,
@@ -1216,6 +2251,111 @@
             "Cyware",
             "cyware-ctix",
             "IP_Enrichment"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "List Rules",
+          "aliasName": null,
+          "tag": "#Cyware CTIX",
+          "description": "Retrieves a list of rules from the platform.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": null,
+          "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/584a7d59-dd7f-41da-a1f9-3fae89dd299e",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "List Rules",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "''",
+                "params": {
+                  "page": 1,
+                  "source": "",
+                  "status": "",
+                  "pageSize": 10,
+                  "createdTo": "",
+                  "createdByID": "",
+                  "createdFrom": null,
+                  "isManualRun": false,
+                  "lastActiveTo": null,
+                  "lastActiveFrom": null
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "list_rules",
+                "operationTitle": "List Rules",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "120",
+              "left": "188",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "9e1904de-a0f0-4f18-a985-a762c3572769"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "762f6fe7-5905-4c5d-b09d-bdd309455cc6",
+                "title": "Cyware CTIX: List Rules",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "584a7d59-dd7f-41da-a1f9-3fae89dd299e"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start-> List Rules",
+              "targetStep": "/api/3/workflow_steps/9e1904de-a0f0-4f18-a985-a762c3572769",
+              "sourceStep": "/api/3/workflow_steps/584a7d59-dd7f-41da-a1f9-3fae89dd299e",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "11a5e686-c872-4070-ac68-4244707c77fb"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "849ac877-2ef3-4191-9bae-f163b8fb60b3",
+          "id": 3229,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "Cyware",
+            "cyware-ctix"
           ]
         },
         {
@@ -1234,11 +2374,32 @@
             "style_colors"
           ],
           "synchronous": false,
-          "lastModifyDate": 1684154748,
+          "lastModifyDate": 1760346614,
           "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
           "versions": [],
           "triggerStep": "/api/3/workflow_steps/5d8e7c30-e11c-4d14-8f6a-22632d964761",
           "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Compute Enrichment Summary",
+              "description": null,
+              "arguments": {
+                "params": {
+                  "value": "<table class=\"no-border\">\n    <tr>\n        <th colspan=\"5\" class=\"no-background padding-0\">\n            <div class=\"font-size-11 ng-binding padding-bottom-sm\">\n                <h4 style=\"color: orange;\"\n                    class=\"body-default-bgcolor margin-bottom-0 padding-bottom-md padding-left-md padding-top-md text-align-left\">\n                    Cyware CTIX Detection Summary</h4>\n            </div>\n        </th>\n    </tr>\n    <tr class=\"solid-border\">\n        <td>\n            <div small class=\"control-label\">Score</div>\n            <div class=\"card-container-body margin-left-0\" style=\"width: 100px;\">\n                <div>{% if vars.steps.Get_Reputation.data.result.score > (vars.malicious_score.split('-')[1] | int) %}</div>\n                <div class=\"body-default-bgcolor card-number padding-left-md\"\n                    style=\"border-left: 5px solid {{vars.input.params.style_colors.Malicious}};padding: 11px;font-size: 18px !important;\">\n                    {{vars.steps.Get_Reputation.data.result.score}}</div>\n                <div>{% elif vars.steps.Get_Reputation.data.result.score > (vars.suspicious_score.split('-')[1] | int) %}</div>\n                <div class=\"body-default-bgcolor card-number padding-left-md\"\n                    style=\"border-left: 5px solid {{vars.input.params.style_colors.Suspicious}};padding: 11px;font-size: 18px !important;\">\n                    {{vars.steps.Get_Reputation.data.result.score}}</div>\n                <div>{% elif vars.steps.Get_Reputation.data.result.score > (vars.good_score.split('-')[1] | int) %}</div>\n                <div class=\"body-default-bgcolor card-number padding-left-md\"\n                    style=\"border-left: 5px solid {{vars.input.params.style_colors.Good}};padding: 11px;font-size: 18px !important;\">\n                    {{vars.steps.Get_Reputation.data.result.score}}</div>\n                <div>{% else %}</div>\n                <div class=\"body-default-bgcolor card-number padding-left-md\"\n                    style=\"border-left: 5px solid {{vars.input.params.style_colors['No Reputation Available']}};padding: 11px;font-size: 18px !important;\">\n                    {{vars.steps.Get_Reputation.data.result.score}}</div>\n                <div>{% endif %}</div>\n            </div>\n        </td>\n    </tr>\n</table>"
+                },
+                "version": "3.2.3",
+                "connector": "cyops_utilities",
+                "operation": "format_richtext",
+                "operationTitle": "Utils: Format as RichText (Markdown)",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "570",
+              "left": "125",
+              "stepType": "/api/3/workflow_step_types/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+              "group": null,
+              "uuid": "32a55bda-c8ea-491d-8450-fba5b945f864"
+            },
             {
               "@type": "WorkflowStep",
               "name": "Configuration",
@@ -1251,11 +2412,37 @@
                 "suspicious_score": "66-34"
               },
               "status": null,
-              "top": "160",
+              "top": "165",
               "left": "300",
               "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
               "group": null,
               "uuid": "0901e870-5570-4189-91f1-ed30f24648c0"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Get Reputation",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "98dc98c3-f61d-4268-a31e-3c54ae8f051a",
+                "params": {
+                  "domain": "{{vars.indicator_value}}",
+                  "page_size": ""
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "search_domain",
+                "mock_result": "{\n    \"data\": {\n        \"message\": \"\",\n        \"result\": {\n            \"package_count\": \"\",\n            \"whois_domain_report\": \"\",\n            \"stix_object_id\": \"\",\n            \"domain_data\": \"demo_data.com\",\n            \"created\": \"\",\n            \"package_details\": [\n                {\n                    \"source_grading\": \"\",\n                    \"intl_grading\": \"\",\n                    \"package_timestamp\": \"\",\n                    \"package_id\": \"\",\n                    \"package_title\": \"\",\n                    \"source_name\": \"\",\n                    \"collection_name\": \"\"\n                }\n            ],\n            \"domain_tld_data\": \".\",\n            \"packages_list\": [],\n            \"updated\": \"\",\n            \"url_data\": [],\n            \"score\": 82\n        }\n    }\n}",
+                "operationTitle": "Search Domain",
+                "pickFromTenant": false,
+                "step_variables": []
+              },
+              "status": null,
+              "top": "300",
+              "left": "300",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "be08bd45-94c9-4986-92a6-dfe0292d30cf"
             },
             {
               "@type": "WorkflowStep",
@@ -1278,7 +2465,7 @@
                 ]
               },
               "status": null,
-              "top": "440",
+              "top": "435",
               "left": "300",
               "stepType": "/api/3/workflow_step_types/12254cf5-5db7-4b1a-8cb1-3af081924b28",
               "group": null,
@@ -1286,16 +2473,14 @@
             },
             {
               "@type": "WorkflowStep",
-              "name": "Compute Enrichment Summary",
+              "name": "No Operation",
               "description": null,
               "arguments": {
-                "params": {
-                  "value": "<table class=\"no-border\">\n    <tr>\n        <th colspan=\"5\" class=\"no-background padding-0\">\n            <div class=\"font-size-11 ng-binding padding-bottom-sm\">\n                <h4 style=\"color: orange;\"\n                    class=\"body-default-bgcolor margin-bottom-0 padding-bottom-md padding-left-md padding-top-md text-align-left\">\n                    Cyware CTIX Detection Summary</h4>\n            </div>\n        </th>\n    </tr>\n    <tr class=\"solid-border\">\n        <td>\n            <div small class=\"control-label\">Score</div>\n            <div class=\"card-container-body margin-left-0\" style=\"width: 100px;\">\n                <div>{% if vars.steps.Get_Reputation.data.result.score > (vars.malicious_score.split('-')[1] | int) %}</div>\n                <div class=\"body-default-bgcolor card-number padding-left-md\"\n                    style=\"border-left: 5px solid {{vars.input.params.style_colors.Malicious}};padding: 11px;font-size: 18px !important;\">\n                    {{vars.steps.Get_Reputation.data.result.score}}</div>\n                <div>{% elif vars.steps.Get_Reputation.data.result.score > (vars.suspicious_score.split('-')[1] | int) %}</div>\n                <div class=\"body-default-bgcolor card-number padding-left-md\"\n                    style=\"border-left: 5px solid {{vars.input.params.style_colors.Suspicious}};padding: 11px;font-size: 18px !important;\">\n                    {{vars.steps.Get_Reputation.data.result.score}}</div>\n                <div>{% elif vars.steps.Get_Reputation.data.result.score > (vars.good_score.split('-')[1] | int) %}</div>\n                <div class=\"body-default-bgcolor card-number padding-left-md\"\n                    style=\"border-left: 5px solid {{vars.input.params.style_colors.Good}};padding: 11px;font-size: 18px !important;\">\n                    {{vars.steps.Get_Reputation.data.result.score}}</div>\n                <div>{% else %}</div>\n                <div class=\"body-default-bgcolor card-number padding-left-md\"\n                    style=\"border-left: 5px solid {{vars.input.params.style_colors['No Reputation Available']}};padding: 11px;font-size: 18px !important;\">\n                    {{vars.steps.Get_Reputation.data.result.score}}</div>\n                <div>{% endif %}</div>\n            </div>\n        </td>\n    </tr>\n</table>"
-                },
+                "params": [],
                 "version": "3.2.3",
                 "connector": "cyops_utilities",
-                "operation": "format_richtext",
-                "operationTitle": "Utils: Format as RichText (Markdown)",
+                "operation": "no_op",
+                "operationTitle": "Utils: No Operation",
                 "step_variables": []
               },
               "status": null,
@@ -1303,7 +2488,25 @@
               "left": "475",
               "stepType": "/api/3/workflow_step_types/0109f35d-090b-4a2b-bd8a-94cbc3508562",
               "group": null,
-              "uuid": "32a55bda-c8ea-491d-8450-fba5b945f864"
+              "uuid": "e4a00c82-1d62-4b4c-8d65-4148a9d9efd1"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Return Output Data",
+              "description": null,
+              "arguments": {
+                "verdict": "{% if vars.steps.Get_Reputation.data.result.score > (vars.malicious_score.split('-')[1] | int) %}{{\"Malicious\"}}{% elif vars.steps.Get_Reputation.data.result.score > (vars.suspicious_score.split('-')[1] | int) %}{{\"Suspicious\"}}{% elif vars.steps.Get_Reputation.data.result.score > (vars.good_score.split('-')[1] | int) %}{{\"Good\"}}{% else %}{{\"No Reputation Available\"}}{% endif %}",
+                "cti_name": "CywareCTIX",
+                "cti_score": "{{vars.steps.Get_Reputation.data.result.score}}",
+                "source_data": "{\"CywareCTIX\": {{vars.steps.Get_Reputation.data}} }",
+                "enrichment_summary": "{{vars.steps.Compute_Enrichment_Summary.data['formatted_string']}}"
+              },
+              "status": null,
+              "top": "705",
+              "left": "125",
+              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+              "group": null,
+              "uuid": "989d906a-7872-4335-aa98-bd4a57f43c54"
             },
             {
               "@type": "WorkflowStep",
@@ -1322,80 +2525,48 @@
               "stepType": "/api/3/workflow_step_types/b348f017-9a94-471f-87f8-ce88b6a7ad62",
               "group": null,
               "uuid": "5d8e7c30-e11c-4d14-8f6a-22632d964761"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Reputation",
-              "description": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "31319c16-be23-43d3-9e71-6d4abbbbf644",
-                "params": {
-                  "domain": "{{vars.indicator_value}}",
-                  "page_size": ""
-                },
-                "version": "1.1.0",
-                "connector": "cyware-ctix",
-                "operation": "search_domain",
-                "mock_result": "{\n    \"data\": {\n        \"message\": \"\",\n        \"result\": {\n            \"package_count\": \"\",\n            \"whois_domain_report\": \"\",\n            \"stix_object_id\": \"\",\n            \"domain_data\": \"demo_data.com\",\n            \"created\": \"\",\n            \"package_details\": [\n                {\n                    \"source_grading\": \"\",\n                    \"intl_grading\": \"\",\n                    \"package_timestamp\": \"\",\n                    \"package_id\": \"\",\n                    \"package_title\": \"\",\n                    \"source_name\": \"\",\n                    \"collection_name\": \"\"\n                }\n            ],\n            \"domain_tld_data\": \".\",\n            \"packages_list\": [],\n            \"updated\": \"\",\n            \"url_data\": [],\n            \"score\": 82\n        }\n    }\n}",
-                "operationTitle": "Search Domain",
-                "pickFromTenant": false,
-                "step_variables": []
-              },
-              "status": null,
-              "top": "300",
-              "left": "300",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "9473e823-0d6b-428d-bbac-73b025e3ebae"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Return Output Data",
-              "description": null,
-              "arguments": {
-                "verdict": "{% if vars.steps.Get_Reputation.data.result.score > (vars.malicious_score.split('-')[1] | int) %}{{\"Malicious\"}}{% elif vars.steps.Get_Reputation.data.result.score > (vars.suspicious_score.split('-')[1] | int) %}{{\"Suspicious\"}}{% elif vars.steps.Get_Reputation.data.result.score > (vars.good_score.split('-')[1] | int) %}{{\"Good\"}}{% else %}{{\"No Reputation Available\"}}{% endif %}",
-                "cti_name": "CywareCTIX",
-                "cti_score": "{{vars.steps.Get_Reputation.data.result.score}}",
-                "source_data": "{\"CywareCTIX\": {{vars.steps.Get_Reputation.data}} }",
-                "enrichment_summary": "{{vars.steps.Compute_Enrichment_Summary.data['formatted_string']}}"
-              },
-              "status": null,
-              "top": "705",
-              "left": "475",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "group": null,
-              "uuid": "989d906a-7872-4335-aa98-bd4a57f43c54"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "No Operation",
-              "description": null,
-              "arguments": {
-                "params": [],
-                "version": "3.2.3",
-                "connector": "cyops_utilities",
-                "operation": "no_op",
-                "operationTitle": "Utils: No Operation",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "570",
-              "left": "125",
-              "stepType": "/api/3/workflow_step_types/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-              "group": null,
-              "uuid": "e4a00c82-1d62-4b4c-8d65-4148a9d9efd1"
             }
           ],
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "name": "Configuration -> Get Reputation2",
-              "targetStep": "/api/3/workflow_steps/9473e823-0d6b-428d-bbac-73b025e3ebae",
+              "name": "Compute Enrichment Summary -> Return Output Data",
+              "targetStep": "/api/3/workflow_steps/989d906a-7872-4335-aa98-bd4a57f43c54",
+              "sourceStep": "/api/3/workflow_steps/32a55bda-c8ea-491d-8450-fba5b945f864",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "72c5725f-95cf-40c1-9a42-a193c8636db6"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Configuration -> Get Reputationa",
+              "targetStep": "/api/3/workflow_steps/be08bd45-94c9-4986-92a6-dfe0292d30cf",
               "sourceStep": "/api/3/workflow_steps/0901e870-5570-4189-91f1-ed30f24648c0",
               "label": null,
               "isExecuted": false,
-              "uuid": "117c0c9f-3633-4e5a-817d-77253735e9e3"
+              "group": null,
+              "uuid": "a3c83b5a-a66f-4017-848a-e35f014b4b17"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Get Reputation -> Is Reputation Found",
+              "targetStep": "/api/3/workflow_steps/28c6c88d-4cef-4bfa-ad7b-6de07109f5a3",
+              "sourceStep": "/api/3/workflow_steps/be08bd45-94c9-4986-92a6-dfe0292d30cf",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "da9b17ee-1d58-4d64-a279-eaa000742532"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Is Reputation Found -> Compute Enrichment Summary",
+              "targetStep": "/api/3/workflow_steps/32a55bda-c8ea-491d-8450-fba5b945f864",
+              "sourceStep": "/api/3/workflow_steps/28c6c88d-4cef-4bfa-ad7b-6de07109f5a3",
+              "label": "Yes",
+              "isExecuted": false,
+              "group": null,
+              "uuid": "96d1a8cb-0222-4450-9393-ad31e9697595"
             },
             {
               "@type": "WorkflowRoute",
@@ -1404,6 +2575,7 @@
               "sourceStep": "/api/3/workflow_steps/28c6c88d-4cef-4bfa-ad7b-6de07109f5a3",
               "label": "No",
               "isExecuted": false,
+              "group": null,
               "uuid": "559b2d6a-28c0-4c1a-9546-bc7bfcac261f"
             },
             {
@@ -1413,46 +2585,815 @@
               "sourceStep": "/api/3/workflow_steps/5d8e7c30-e11c-4d14-8f6a-22632d964761",
               "label": null,
               "isExecuted": false,
+              "group": null,
               "uuid": "68da1a50-1e95-4dc0-93f6-b59a81cfd99a"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Compute Enrichment Summary -> Return Output Data",
-              "targetStep": "/api/3/workflow_steps/989d906a-7872-4335-aa98-bd4a57f43c54",
-              "sourceStep": "/api/3/workflow_steps/32a55bda-c8ea-491d-8450-fba5b945f864",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "72c5725f-95cf-40c1-9a42-a193c8636db6"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Is Reputation Found -> Compute Enrichment Summary",
-              "targetStep": "/api/3/workflow_steps/32a55bda-c8ea-491d-8450-fba5b945f864",
-              "sourceStep": "/api/3/workflow_steps/28c6c88d-4cef-4bfa-ad7b-6de07109f5a3",
-              "label": "Yes",
-              "isExecuted": false,
-              "uuid": "96d1a8cb-0222-4450-9393-ad31e9697595"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Get Reputation2 -> Is Reputation Found",
-              "targetStep": "/api/3/workflow_steps/28c6c88d-4cef-4bfa-ad7b-6de07109f5a3",
-              "sourceStep": "/api/3/workflow_steps/9473e823-0d6b-428d-bbac-73b025e3ebae",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "dd2d3b75-bf83-4996-b79f-8d82fd470aeb"
             }
           ],
           "groups": [],
           "priority": "/api/3/picklists/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
           "uuid": "85529222-dd89-4b89-9b96-43c55d0ab663",
-          "id": 3701,
+          "id": 3215,
           "owners": [],
           "isPrivate": false,
           "deletedAt": null,
           "importedBy": [],
           "recordTags": [
-            "Domain_Enrichment",
+            "Cyware",
+            "cyware-ctix",
+            "Domain_Enrichment"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Create Custom Attribute",
+          "aliasName": null,
+          "tag": "#Cyware CTIX",
+          "description": "Create a custom attribute in the platform.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": null,
+          "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/f3e07787-018b-4303-8b7f-64a56683ec7c",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Create Custom Attribute",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "''",
+                "params": {
+                  "name": "",
+                  "type": null,
+                  "status": "1",
+                  "choices": null,
+                  "description": "",
+                  "sdo_objects": null,
+                  "is_actionable": false
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "create_custom_attribute",
+                "operationTitle": "Create Custom Attribute",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "120",
+              "left": "188",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "3c3262e5-65d9-453c-b22a-a849c4797567"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "1fbf3177-7d1b-47c7-b8de-4b897efe8a77",
+                "title": "Cyware CTIX: Create Custom Attribute",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "f3e07787-018b-4303-8b7f-64a56683ec7c"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start-> Create Custom Attribute",
+              "targetStep": "/api/3/workflow_steps/3c3262e5-65d9-453c-b22a-a849c4797567",
+              "sourceStep": "/api/3/workflow_steps/f3e07787-018b-4303-8b7f-64a56683ec7c",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "cd5eade3-1a74-4c34-b476-79f888ce572b"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "89c9002d-57c6-42f0-be8b-73477d03ac9d",
+          "id": 3242,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "Cyware",
+            "cyware-ctix"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Bulk IOC Lookup and Create Intel",
+          "aliasName": null,
+          "tag": "#Cyware CTIX",
+          "description": "Performs a bulk IOC lookup by fetching a list of threat data objects present in the CTIX application. If some IOCs are not present in the application, then you can choose to ingest the missing IOCs and create new records. NOTE: You can perform the lookup and further ingest a maximum of 1000 IOCs in the application at any moment.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": null,
+          "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/b6966c3b-b850-4b99-9eb5-4bf828d5e933",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Bulk IOC Lookup and Create Intel",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "''",
+                "params": {
+                  "create": false,
+                  "source": "OpenAPI Lookup (OpenAPI)",
+                  "metadata": null,
+                  "collection": "OpenAPI Lookup (OpenAPI)",
+                  "enrichment": false
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "bulk_ioc_lookup_and_create_intel",
+                "operationTitle": "Bulk IOC Lookup and Create Intel",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "120",
+              "left": "188",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "d4d79127-211c-4b5a-b2e9-1b2852ed6091"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "1fe62d2c-37ed-488e-a540-3fe9f98cf04e",
+                "title": "Cyware CTIX: Bulk IOC Lookup and Create Intel",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "b6966c3b-b850-4b99-9eb5-4bf828d5e933"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start-> Bulk IOC Lookup and Create Intel",
+              "targetStep": "/api/3/workflow_steps/d4d79127-211c-4b5a-b2e9-1b2852ed6091",
+              "sourceStep": "/api/3/workflow_steps/b6966c3b-b850-4b99-9eb5-4bf828d5e933",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "5676af15-2fdd-4628-9eba-97061608b5ac"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "95604b1a-0032-41c0-9dbe-09d9c592965c",
+          "id": 3222,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "Cyware",
+            "cyware-ctix"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Delete Allowed Indicator",
+          "aliasName": null,
+          "tag": "#Cyware CTIX",
+          "description": "Deletes a particular allowed indicator entry from the dashboard.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": null,
+          "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/978984bb-a783-4073-a806-16bac646f3af",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Delete Allowed Indicator",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "''",
+                "params": {
+                  "indicator_id": ""
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "delete_allowed_indicator",
+                "operationTitle": "Delete Allowed Indicator",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "120",
+              "left": "188",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "bc4af83e-7715-40b8-ac25-09c8a65f84fe"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "bc186358-2464-45cb-87c9-fc015a2a2470",
+                "title": "Cyware CTIX: Delete Allowed Indicator",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "978984bb-a783-4073-a806-16bac646f3af"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start-> Delete Allowed Indicator",
+              "targetStep": "/api/3/workflow_steps/bc4af83e-7715-40b8-ac25-09c8a65f84fe",
+              "sourceStep": "/api/3/workflow_steps/978984bb-a783-4073-a806-16bac646f3af",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "642acc85-8317-4538-85b5-45345abd1b3b"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "9af96fbf-140c-4908-a67f-9af1b0607cb8",
+          "id": 3238,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "Cyware",
+            "cyware-ctix"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Get Threat Data Object Details List",
+          "aliasName": null,
+          "tag": "#Cyware CTIX",
+          "description": "Returns basic correlated details of a threat data object in Intel Exchange.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": null,
+          "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/8ab52509-3b6e-4061-a5c8-aa70069cdcd7",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Get Threat Data Object Details List",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "''",
+                "params": {
+                  "objectID": "",
+                  "object_type": ""
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "list_threat_data_object_details",
+                "operationTitle": "Get Threat Data Object Details List",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "120",
+              "left": "188",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "eaf99e70-7564-443d-b8f4-91d9d9fa8e34"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "e46dd51c-cef1-4b4d-a99e-19fb758521b0",
+                "title": "Cyware CTIX: Get Threat Data Object Details List",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "8ab52509-3b6e-4061-a5c8-aa70069cdcd7"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start-> Get Threat Data Object Details List",
+              "targetStep": "/api/3/workflow_steps/eaf99e70-7564-443d-b8f4-91d9d9fa8e34",
+              "sourceStep": "/api/3/workflow_steps/8ab52509-3b6e-4061-a5c8-aa70069cdcd7",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "add1c8b3-a134-4d2f-8882-cfa30e5458df"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "a2c8f737-9362-41bc-bd96-c28ef36d6aa9",
+          "id": 3224,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "Cyware",
+            "cyware-ctix"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Create Report",
+          "aliasName": null,
+          "tag": "#Cyware CTIX",
+          "description": "Creates a basic (standard) report in CTIX.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": null,
+          "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/96978eeb-ddef-4e2e-9c31-32ea46f70a39",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Create Report",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "''",
+                "params": {
+                  "name": "",
+                  "type": "basic",
+                  "columns": null,
+                  "schedule": null,
+                  "query_key": "ctix_created",
+                  "file_types": null,
+                  "shared_type": null,
+                  "saved_search": null,
+                  "basic_report_type": "custom",
+                  "external_recipients": null,
+                  "internal_recipients": null
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "create_report",
+                "operationTitle": "Create Report",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "120",
+              "left": "188",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "4a77c083-a64c-4a5d-8b84-34143f037dd0"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "586b1d8e-f76b-478e-af14-7e6ca158e152",
+                "title": "Cyware CTIX: Create Report",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "96978eeb-ddef-4e2e-9c31-32ea46f70a39"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start-> Create Report",
+              "targetStep": "/api/3/workflow_steps/4a77c083-a64c-4a5d-8b84-34143f037dd0",
+              "sourceStep": "/api/3/workflow_steps/96978eeb-ddef-4e2e-9c31-32ea46f70a39",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "8c7bb499-5a9e-4838-a785-f59a357f32cf"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "a64fb8b5-48d2-4b34-b145-d7967d348d66",
+          "id": 3240,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "Cyware",
+            "cyware-ctix"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Delete Tag",
+          "aliasName": null,
+          "tag": "#Cyware CTIX",
+          "description": "Deletes a tag by the tag ID.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": null,
+          "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/36daa82f-1517-465e-b7cf-213e4cdbe372",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Delete Tag",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "''",
+                "params": {
+                  "tag_id": ""
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "delete_tag",
+                "operationTitle": "Delete Tag",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "120",
+              "left": "188",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "8a541a16-51a0-47b1-8191-9913930f6f92"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "efd85552-d140-4fb6-9d6a-7e30352d606b",
+                "title": "Cyware CTIX: Delete Tag",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "36daa82f-1517-465e-b7cf-213e4cdbe372"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start-> Delete Tag",
+              "targetStep": "/api/3/workflow_steps/8a541a16-51a0-47b1-8191-9913930f6f92",
+              "sourceStep": "/api/3/workflow_steps/36daa82f-1517-465e-b7cf-213e4cdbe372",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "e2bb8d12-9114-4138-a55f-6ed1bdee4c9f"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "b3021d4d-a33e-404c-bfa7-9f64908be8b4",
+          "id": 3236,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "Cyware",
+            "cyware-ctix"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Get Enrichment Tool List",
+          "aliasName": null,
+          "tag": "#Cyware CTIX",
+          "description": "Returns the list of enrichment tools configured in Intel Exchange.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": null,
+          "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/70f960fb-c5a4-4c1f-89f8-b2bbda3fe0ae",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Get Enrichment Tool List",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "''",
+                "params": {
+                  "component": "",
+                  "full_list": "true",
+                  "action_name": null
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "enrichment_tools",
+                "operationTitle": "Get Enrichment Tool List",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "120",
+              "left": "188",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "00ae2c38-63d7-4877-b2e1-f5f0396e3c03"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "97d61075-ec15-4a93-a266-a01cf3882560",
+                "title": "Cyware CTIX: Get Enrichment Tool List",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "70f960fb-c5a4-4c1f-89f8-b2bbda3fe0ae"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start-> Get Enrichment Tool List",
+              "targetStep": "/api/3/workflow_steps/00ae2c38-63d7-4877-b2e1-f5f0396e3c03",
+              "sourceStep": "/api/3/workflow_steps/70f960fb-c5a4-4c1f-89f8-b2bbda3fe0ae",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "407f70d8-9b81-42f1-b33a-dfe33c622aa9"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "be15a88d-f046-42c8-a3e3-c18b393a4e2e",
+          "id": 3231,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "Cyware",
+            "cyware-ctix"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Run Rule",
+          "aliasName": null,
+          "tag": "#Cyware CTIX",
+          "description": "Runs a rule asynchronously on the existing threat data created in the specified time interval.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": null,
+          "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/cb5fcc9f-ee02-4778-bbdb-dd7df17d5024",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Run Rule",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "''",
+                "params": {
+                  "rule": "",
+                  "endTime": null,
+                  "startTime": null
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "run_rule",
+                "operationTitle": "Run Rule",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "120",
+              "left": "188",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "b8ace1ed-878e-43e9-8d56-dce9a6a3741d"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "312fba2a-6147-418d-9416-12f079612ebf",
+                "title": "Cyware CTIX: Run Rule",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "cb5fcc9f-ee02-4778-bbdb-dd7df17d5024"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start-> Run Rule",
+              "targetStep": "/api/3/workflow_steps/b8ace1ed-878e-43e9-8d56-dce9a6a3741d",
+              "sourceStep": "/api/3/workflow_steps/cb5fcc9f-ee02-4778-bbdb-dd7df17d5024",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "b077788b-16fa-4616-9222-02d82f34571b"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "bfa159d7-1070-44ab-8b86-b54eb8796ba7",
+          "id": 3230,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
             "Cyware",
             "cyware-ctix"
           ]
@@ -1470,11 +3411,36 @@
           "remoteExecutableFlag": false,
           "parameters": [],
           "synchronous": false,
-          "lastModifyDate": null,
+          "lastModifyDate": 1760347096,
           "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
           "versions": [],
           "triggerStep": "/api/3/workflow_steps/184cb858-28fc-40df-b939-1f2f10c6200f",
           "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Search Hash",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "98dc98c3-f61d-4268-a31e-3c54ae8f051a",
+                "params": {
+                  "hash": "{{}}",
+                  "page_size": ""
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "search_hash",
+                "operationTitle": "Search Hash",
+                "pickFromTenant": false,
+                "step_variables": []
+              },
+              "status": null,
+              "top": "182",
+              "left": "350",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "97d820f4-edec-46af-a284-4b2b376a7db3"
+            },
             {
               "@type": "WorkflowStep",
               "name": "Start",
@@ -1501,49 +3467,26 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
               "group": null,
               "uuid": "184cb858-28fc-40df-b939-1f2f10c6200f"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Search Hash",
-              "description": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "''",
-                "params": {
-                  "hash": "",
-                  "page_size": ""
-                },
-                "version": "1.1.0",
-                "connector": "cyware-ctix",
-                "operation": "search_hash",
-                "operationTitle": "Search Hash",
-                "step_variables": {
-                  "output_data": "{{vars.result}}"
-                }
-              },
-              "status": null,
-              "top": "120",
-              "left": "188",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "189b5836-dbac-4666-818d-87940ae65e52"
             }
           ],
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "name": "Start-> Search Hash",
-              "targetStep": "/api/3/workflow_steps/189b5836-dbac-4666-818d-87940ae65e52",
+              "name": "Start -> Search Hash",
+              "targetStep": "/api/3/workflow_steps/97d820f4-edec-46af-a284-4b2b376a7db3",
               "sourceStep": "/api/3/workflow_steps/184cb858-28fc-40df-b939-1f2f10c6200f",
               "label": null,
               "isExecuted": false,
-              "uuid": "7c9e416e-9245-4bc8-8717-1d559ba2dc1c"
+              "group": null,
+              "uuid": "4221509f-fadc-4a2f-a984-2afc0fd01e7c"
             }
           ],
           "groups": [],
           "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
           "uuid": "ca34a5bd-9a13-40c3-978a-4d261011a283",
-          "id": 3702,
+          "id": 3216,
           "owners": [],
           "isPrivate": false,
           "deletedAt": null,
@@ -1555,1865 +3498,61 @@
         },
         {
           "@type": "Workflow",
-          "uuid": "17606a9b-6be1-401f-a781-599507eb0a21",
-          "collection": "/api/3/workflow_collections/675d21d5-03ec-4286-a40a-f7a02fcedab3",
           "triggerLimit": null,
-          "description": "Create intel with additional details such as the source and collection. You can also include details for each object, such as description, notes, custom attributes, and more.",
-          "name": "Create Intel via Open API",
-          "tag": "#Cyware CTIX",
-          "recordTags": [
-            "Cyware",
-            "cyware-ctix"
-          ],
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "parameters": [],
-          "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/12b33eb8-d935-4c37-b748-670cff917010",
-          "steps": [
-            {
-              "uuid": "12b33eb8-d935-4c37-b748-670cff917010",
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "route": "22f1c19f-a216-4077-abd5-a96a42259f89",
-                "title": "Cyware CTIX: Create Intel via Open API",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "singleRecordExecution": false,
-                "noRecordExecution": true,
-                "executeButtonText": "Execute"
-              },
-              "left": "20",
-              "top": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
-            },
-            {
-              "uuid": "461ccb1c-42b8-48e6-9819-f01cd3769d7d",
-              "@type": "WorkflowStep",
-              "name": "Create Intel via Open API",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "''",
-                "params": {
-                  "title": "",
-                  "allSDOS": null,
-                  "source": "Miscellaneous",
-                  "collection": "Free Text",
-                  "metadata": null
-                },
-                "version": "2.0.0",
-                "connector": "cyware-ctix",
-                "operation": "create_intel_via_open_api",
-                "operationTitle": "Create Intel via Open API",
-                "step_variables": {}
-              },
-              "left": "188",
-              "top": "120",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "445741ba-be9a-49c6-a0b6-31bab66b66e6",
-              "label": null,
-              "isExecuted": false,
-              "name": "Start-> Create Intel via Open API",
-              "sourceStep": "/api/3/workflow_steps/12b33eb8-d935-4c37-b748-670cff917010",
-              "targetStep": "/api/3/workflow_steps/461ccb1c-42b8-48e6-9819-f01cd3769d7d"
-            }
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "uuid": "462fc98e-a501-458d-aa48-82ced1c04cbb",
-          "collection": "/api/3/workflow_collections/675d21d5-03ec-4286-a40a-f7a02fcedab3",
-          "triggerLimit": null,
-          "description": "Returns a list of threat data objects from the CTIX application. You can retrieve a maximum of 500,000 threat data objects using this API.",
-          "name": "Get Threat Data",
-          "tag": "#Cyware CTIX",
-          "recordTags": [
-            "Cyware",
-            "cyware-ctix"
-          ],
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "parameters": [],
-          "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/e8182d84-23fb-49d2-b3a5-e4e667805317",
-          "steps": [
-            {
-              "uuid": "e8182d84-23fb-49d2-b3a5-e4e667805317",
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "route": "e49302c6-1cd1-4a54-aa89-102f0ba20270",
-                "title": "Cyware CTIX: Get Threat Data",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "singleRecordExecution": false,
-                "noRecordExecution": true,
-                "executeButtonText": "Execute"
-              },
-              "left": "20",
-              "top": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
-            },
-            {
-              "uuid": "c991224a-d8e6-4e8a-899a-1d19a6c044ed",
-              "@type": "WorkflowStep",
-              "name": "Get Threat Data",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "''",
-                "params": {
-                  "query": "",
-                  "page": 1,
-                  "page_size": 1,
-                  "page_limit": 10,
-                  "enrichment": true,
-                  "sort": "-ctix_created"
-                },
-                "version": "2.0.0",
-                "connector": "cyware-ctix",
-                "operation": "list_threat_data",
-                "operationTitle": "Get Threat Data",
-                "step_variables": {}
-              },
-              "left": "188",
-              "top": "120",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "7d30aec0-7b39-4a1a-88ea-2c4fdb5c28b7",
-              "label": null,
-              "isExecuted": false,
-              "name": "Start-> Get Threat Data",
-              "sourceStep": "/api/3/workflow_steps/e8182d84-23fb-49d2-b3a5-e4e667805317",
-              "targetStep": "/api/3/workflow_steps/c991224a-d8e6-4e8a-899a-1d19a6c044ed"
-            }
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "uuid": "0d6f62c1-7319-46b5-a3bc-d68a81530971",
-          "collection": "/api/3/workflow_collections/675d21d5-03ec-4286-a40a-f7a02fcedab3",
-          "triggerLimit": null,
-          "description": "Add a relation to multiple threat data objects.",
-          "name": "Bulk Add Relation",
-          "tag": "#Cyware CTIX",
-          "recordTags": [
-            "Cyware",
-            "cyware-ctix"
-          ],
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "parameters": [],
-          "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/d9e6e097-ebc4-40f0-9065-4a1c94085c87",
-          "steps": [
-            {
-              "uuid": "d9e6e097-ebc4-40f0-9065-4a1c94085c87",
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "route": "d6ea9f24-ed76-4f3b-bdc1-98f8f77575d1",
-                "title": "Cyware CTIX: Bulk Add Relation",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "singleRecordExecution": false,
-                "noRecordExecution": true,
-                "executeButtonText": "Execute"
-              },
-              "left": "20",
-              "top": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
-            },
-            {
-              "uuid": "75dd68de-2466-4f93-aadf-635af1d7717f",
-              "@type": "WorkflowStep",
-              "name": "Bulk Add Relation",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "''",
-                "params": {
-                  "object_ids": null,
-                  "object_type": "",
-                  "data": null
-                },
-                "version": "2.0.0",
-                "connector": "cyware-ctix",
-                "operation": "bulk_add_relation",
-                "operationTitle": "Bulk Add Relation",
-                "step_variables": {}
-              },
-              "left": "188",
-              "top": "120",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "915550bf-d8e8-4e24-9fb9-c71da7f59fa6",
-              "label": null,
-              "isExecuted": false,
-              "name": "Start-> Bulk Add Relation",
-              "sourceStep": "/api/3/workflow_steps/d9e6e097-ebc4-40f0-9065-4a1c94085c87",
-              "targetStep": "/api/3/workflow_steps/75dd68de-2466-4f93-aadf-635af1d7717f"
-            }
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "uuid": "f68c4531-84a3-497e-8183-4caba6b7d89f",
-          "collection": "/api/3/workflow_collections/675d21d5-03ec-4286-a40a-f7a02fcedab3",
-          "triggerLimit": null,
-          "description": "Deprecate or undeprecate multiple threat data objects with one API request.",
-          "name": "Bulk Deprecate/Undeprecate Objects",
-          "tag": "#Cyware CTIX",
-          "recordTags": [
-            "Cyware",
-            "cyware-ctix"
-          ],
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "parameters": [],
-          "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/39a52948-2877-431c-91a9-552ad03a9f0a",
-          "steps": [
-            {
-              "uuid": "39a52948-2877-431c-91a9-552ad03a9f0a",
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "route": "075779ac-5a74-4bee-9bc6-a67ec7f1aad0",
-                "title": "Cyware CTIX: Bulk Deprecate/Undeprecate Objects",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "singleRecordExecution": false,
-                "noRecordExecution": true,
-                "executeButtonText": "Execute"
-              },
-              "left": "20",
-              "top": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
-            },
-            {
-              "uuid": "5cbd830c-d609-4aac-b617-d373d9ddedeb",
-              "@type": "WorkflowStep",
-              "name": "Bulk Deprecate/Undeprecate Objects",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "''",
-                "params": {
-                  "object_ids": "",
-                  "object_type": "",
-                  "action_type": "deprecate"
-                },
-                "version": "2.0.0",
-                "connector": "cyware-ctix",
-                "operation": "bulk_deprecate_undeprecate_objects",
-                "operationTitle": "Bulk Deprecate/Undeprecate Objects",
-                "step_variables": {}
-              },
-              "left": "188",
-              "top": "120",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "968ef713-86b1-4df2-889a-d06c02999b50",
-              "label": null,
-              "isExecuted": false,
-              "name": "Start-> Bulk Deprecate/Undeprecate Objects",
-              "sourceStep": "/api/3/workflow_steps/39a52948-2877-431c-91a9-552ad03a9f0a",
-              "targetStep": "/api/3/workflow_steps/5cbd830c-d609-4aac-b617-d373d9ddedeb"
-            }
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "uuid": "4d5d3dd3-4a53-4b15-9c48-c66a83413369",
-          "collection": "/api/3/workflow_collections/675d21d5-03ec-4286-a40a-f7a02fcedab3",
-          "triggerLimit": null,
-          "description": "Mark or unmark multiple IOCs as false positives.",
-          "name": "Bulk Mark/Unmark False Positive",
-          "tag": "#Cyware CTIX",
-          "recordTags": [
-            "Cyware",
-            "cyware-ctix"
-          ],
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "parameters": [],
-          "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/30676854-1901-4644-8a7d-de9d42082c51",
-          "steps": [
-            {
-              "uuid": "30676854-1901-4644-8a7d-de9d42082c51",
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "route": "e6501d7e-f80b-4216-a1e0-5a56cf640ecc",
-                "title": "Cyware CTIX: Bulk Mark/Unmark False Positive",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "singleRecordExecution": false,
-                "noRecordExecution": true,
-                "executeButtonText": "Execute"
-              },
-              "left": "20",
-              "top": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
-            },
-            {
-              "uuid": "406df572-71ac-45c2-9b56-3456019fce42",
-              "@type": "WorkflowStep",
-              "name": "Bulk Mark/Unmark False Positive",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "''",
-                "params": {
-                  "object_ids": "",
-                  "object_type": "",
-                  "action_type": "false_positive"
-                },
-                "version": "2.0.0",
-                "connector": "cyware-ctix",
-                "operation": "bulk_mark_unmark_false_positive",
-                "operationTitle": "Bulk Mark/Unmark False Positive",
-                "step_variables": {}
-              },
-              "left": "188",
-              "top": "120",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "216e2b38-34c0-4d65-b380-56b61fce5ab2",
-              "label": null,
-              "isExecuted": false,
-              "name": "Start-> Bulk Mark/Unmark False Positive",
-              "sourceStep": "/api/3/workflow_steps/30676854-1901-4644-8a7d-de9d42082c51",
-              "targetStep": "/api/3/workflow_steps/406df572-71ac-45c2-9b56-3456019fce42"
-            }
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "uuid": "95604b1a-0032-41c0-9dbe-09d9c592965c",
-          "collection": "/api/3/workflow_collections/675d21d5-03ec-4286-a40a-f7a02fcedab3",
-          "triggerLimit": null,
-          "description": "Performs a bulk IOC lookup by fetching a list of threat data objects present in the CTIX application. If some IOCs are not present in the application, then you can choose to ingest the missing IOCs and create new records. NOTE: You can perform the lookup and further ingest a maximum of 1000 IOCs in the application at any moment.",
-          "name": "Bulk IOC Lookup and Create Intel",
-          "tag": "#Cyware CTIX",
-          "recordTags": [
-            "Cyware",
-            "cyware-ctix"
-          ],
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "parameters": [],
-          "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/b6966c3b-b850-4b99-9eb5-4bf828d5e933",
-          "steps": [
-            {
-              "uuid": "b6966c3b-b850-4b99-9eb5-4bf828d5e933",
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "route": "1fe62d2c-37ed-488e-a540-3fe9f98cf04e",
-                "title": "Cyware CTIX: Bulk IOC Lookup and Create Intel",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "singleRecordExecution": false,
-                "noRecordExecution": true,
-                "executeButtonText": "Execute"
-              },
-              "left": "20",
-              "top": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
-            },
-            {
-              "uuid": "d4d79127-211c-4b5a-b2e9-1b2852ed6091",
-              "@type": "WorkflowStep",
-              "name": "Bulk IOC Lookup and Create Intel",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "''",
-                "params": {
-                  "source": "OpenAPI Lookup (OpenAPI)",
-                  "collection": "OpenAPI Lookup (OpenAPI)",
-                  "metadata": null,
-                  "create": false,
-                  "enrichment": false
-                },
-                "version": "2.0.0",
-                "connector": "cyware-ctix",
-                "operation": "bulk_ioc_lookup_and_create_intel",
-                "operationTitle": "Bulk IOC Lookup and Create Intel",
-                "step_variables": {}
-              },
-              "left": "188",
-              "top": "120",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "5676af15-2fdd-4628-9eba-97061608b5ac",
-              "label": null,
-              "isExecuted": false,
-              "name": "Start-> Bulk IOC Lookup and Create Intel",
-              "sourceStep": "/api/3/workflow_steps/b6966c3b-b850-4b99-9eb5-4bf828d5e933",
-              "targetStep": "/api/3/workflow_steps/d4d79127-211c-4b5a-b2e9-1b2852ed6091"
-            }
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "uuid": "0c4d0419-b3af-4040-a957-d1a234a4866f",
-          "collection": "/api/3/workflow_collections/675d21d5-03ec-4286-a40a-f7a02fcedab3",
-          "triggerLimit": null,
-          "description": "Performs a lookup for threat data objects in the CTIX platform and retrieves the details of the objects, such as basic details, enriched data, and relations.",
-          "name": "Bulk IOC Lookup (Advanced)",
-          "tag": "#Cyware CTIX",
-          "recordTags": [
-            "Cyware",
-            "cyware-ctix"
-          ],
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "parameters": [],
-          "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/8aaf9da4-e46e-4533-b202-5b9968cac674",
-          "steps": [
-            {
-              "uuid": "8aaf9da4-e46e-4533-b202-5b9968cac674",
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "route": "4aedea24-79b4-4f2a-8879-2280af47a066",
-                "title": "Cyware CTIX: Bulk IOC Lookup (Advanced)",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "singleRecordExecution": false,
-                "noRecordExecution": true,
-                "executeButtonText": "Execute"
-              },
-              "left": "20",
-              "top": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
-            },
-            {
-              "uuid": "a3a8c955-77e3-4a4d-a8c9-ddf3a9d79443",
-              "@type": "WorkflowStep",
-              "name": "Bulk IOC Lookup (Advanced)",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "''",
-                "params": {
-                  "object_type": "",
-                  "value": "",
-                  "objectID": "",
-                  "enrichment_data": false,
-                  "relation_data": false,
-                  "enrichment_tools": "",
-                  "fields": ""
-                },
-                "version": "2.0.0",
-                "connector": "cyware-ctix",
-                "operation": "bulk_ioc_lookup_advanced",
-                "operationTitle": "Bulk IOC Lookup (Advanced)",
-                "step_variables": {}
-              },
-              "left": "188",
-              "top": "120",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "677da33e-b0c7-4876-a767-2efd4b36e3f3",
-              "label": null,
-              "isExecuted": false,
-              "name": "Start-> Bulk IOC Lookup (Advanced)",
-              "sourceStep": "/api/3/workflow_steps/8aaf9da4-e46e-4533-b202-5b9968cac674",
-              "targetStep": "/api/3/workflow_steps/a3a8c955-77e3-4a4d-a8c9-ddf3a9d79443"
-            }
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "uuid": "a2c8f737-9362-41bc-bd96-c28ef36d6aa9",
-          "collection": "/api/3/workflow_collections/675d21d5-03ec-4286-a40a-f7a02fcedab3",
-          "triggerLimit": null,
-          "description": "Returns basic correlated details of a threat data object in Intel Exchange.",
-          "name": "Get Threat Data Object Details List",
-          "tag": "#Cyware CTIX",
-          "recordTags": [
-            "Cyware",
-            "cyware-ctix"
-          ],
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "parameters": [],
-          "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/8ab52509-3b6e-4061-a5c8-aa70069cdcd7",
-          "steps": [
-            {
-              "uuid": "8ab52509-3b6e-4061-a5c8-aa70069cdcd7",
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "route": "e46dd51c-cef1-4b4d-a99e-19fb758521b0",
-                "title": "Cyware CTIX: Get Threat Data Object Details List",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "singleRecordExecution": false,
-                "noRecordExecution": true,
-                "executeButtonText": "Execute"
-              },
-              "left": "20",
-              "top": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
-            },
-            {
-              "uuid": "eaf99e70-7564-443d-b8f4-91d9d9fa8e34",
-              "@type": "WorkflowStep",
-              "name": "Get Threat Data Object Details List",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "''",
-                "params": {
-                  "object_type": "",
-                  "objectID": ""
-                },
-                "version": "2.0.0",
-                "connector": "cyware-ctix",
-                "operation": "list_threat_data_object_details",
-                "operationTitle": "Get Threat Data Object Details List",
-                "step_variables": {}
-              },
-              "left": "188",
-              "top": "120",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "add1c8b3-a134-4d2f-8882-cfa30e5458df",
-              "label": null,
-              "isExecuted": false,
-              "name": "Start-> Get Threat Data Object Details List",
-              "sourceStep": "/api/3/workflow_steps/8ab52509-3b6e-4061-a5c8-aa70069cdcd7",
-              "targetStep": "/api/3/workflow_steps/eaf99e70-7564-443d-b8f4-91d9d9fa8e34"
-            }
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "uuid": "d2d91d00-298d-4f44-8cb1-a09d02f1c8ed",
-          "collection": "/api/3/workflow_collections/675d21d5-03ec-4286-a40a-f7a02fcedab3",
-          "triggerLimit": null,
-          "description": "Retrieves additional information of a threat data object, such as, kill chain phases and published collections.",
-          "name": "Get Threat Data Object Additional Details",
-          "tag": "#Cyware CTIX",
-          "recordTags": [
-            "Cyware",
-            "cyware-ctix"
-          ],
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "parameters": [],
-          "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/57d582bc-4760-4f98-b8ce-071c28ff453a",
-          "steps": [
-            {
-              "uuid": "57d582bc-4760-4f98-b8ce-071c28ff453a",
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "route": "835ba3db-60a6-4ac2-b60d-f3e093cd564a",
-                "title": "Cyware CTIX: Get Threat Data Object Additional Details",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "singleRecordExecution": false,
-                "noRecordExecution": true,
-                "executeButtonText": "Execute"
-              },
-              "left": "20",
-              "top": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
-            },
-            {
-              "uuid": "9efacd7a-ac12-495a-8f84-0084ed90d85e",
-              "@type": "WorkflowStep",
-              "name": "Get Threat Data Object Additional Details",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "''",
-                "params": {
-                  "object_type": "",
-                  "object_id": ""
-                },
-                "version": "2.0.0",
-                "connector": "cyware-ctix",
-                "operation": "threat_data_object_advanced_details",
-                "operationTitle": "Get Threat Data Object Additional Details",
-                "step_variables": {}
-              },
-              "left": "188",
-              "top": "120",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "b493f880-a934-421b-8c06-036a5d6f2c86",
-              "label": null,
-              "isExecuted": false,
-              "name": "Start-> Get Threat Data Object Additional Details",
-              "sourceStep": "/api/3/workflow_steps/57d582bc-4760-4f98-b8ce-071c28ff453a",
-              "targetStep": "/api/3/workflow_steps/9efacd7a-ac12-495a-8f84-0084ed90d85e"
-            }
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "uuid": "1ffc2ed0-bca6-4da6-a837-14f759df8528",
-          "collection": "/api/3/workflow_collections/675d21d5-03ec-4286-a40a-f7a02fcedab3",
-          "triggerLimit": null,
-          "description": "Retrieves the list of relations and the relation details of a threat data object.",
-          "name": "Get Relations List of Threat Data Object",
-          "tag": "#Cyware CTIX",
-          "recordTags": [
-            "Cyware",
-            "cyware-ctix"
-          ],
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "parameters": [],
-          "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/2f506458-448c-4d02-920f-36f85891b77a",
-          "steps": [
-            {
-              "uuid": "2f506458-448c-4d02-920f-36f85891b77a",
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "route": "c4ddb8fc-074d-4245-be48-2e45a30fe084",
-                "title": "Cyware CTIX: Get Relations List of Threat Data Object",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "singleRecordExecution": false,
-                "noRecordExecution": true,
-                "executeButtonText": "Execute"
-              },
-              "left": "20",
-              "top": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
-            },
-            {
-              "uuid": "150dfde0-96dd-4968-be11-930e779ca424",
-              "@type": "WorkflowStep",
-              "name": "Get Relations List of Threat Data Object",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "''",
-                "params": {
-                  "objectID": "",
-                  "objectType": "",
-                  "sources": "",
-                  "page": 1,
-                  "page_size": 10
-                },
-                "version": "2.0.0",
-                "connector": "cyware-ctix",
-                "operation": "list_relations_of_threat_data_object",
-                "operationTitle": "Get Relations List of Threat Data Object",
-                "step_variables": {}
-              },
-              "left": "188",
-              "top": "120",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "00e8ea2d-c2d6-407a-a711-e6b61bc587d1",
-              "label": null,
-              "isExecuted": false,
-              "name": "Start-> Get Relations List of Threat Data Object",
-              "sourceStep": "/api/3/workflow_steps/2f506458-448c-4d02-920f-36f85891b77a",
-              "targetStep": "/api/3/workflow_steps/150dfde0-96dd-4968-be11-930e779ca424"
-            }
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "uuid": "d5003a4e-e685-4f21-b747-646129700c9a",
-          "collection": "/api/3/workflow_collections/675d21d5-03ec-4286-a40a-f7a02fcedab3",
-          "triggerLimit": null,
-          "description": "Creates a threat bulletin.",
-          "name": "Create Threat Bulletin",
-          "tag": "#Cyware CTIX",
-          "recordTags": [
-            "Cyware",
-            "cyware-ctix"
-          ],
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "parameters": [],
-          "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/c77ce3a9-3be3-42f8-ac54-8e9f4dfe91a6",
-          "steps": [
-            {
-              "uuid": "c77ce3a9-3be3-42f8-ac54-8e9f4dfe91a6",
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "route": "6c86f4d7-4d1d-4291-a07e-135eaee871f0",
-                "title": "Cyware CTIX: Create Threat Bulletin",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "singleRecordExecution": false,
-                "noRecordExecution": true,
-                "executeButtonText": "Execute"
-              },
-              "left": "20",
-              "top": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
-            },
-            {
-              "uuid": "ea9a6fe8-dff1-473a-a243-fc670fdde5b7",
-              "@type": "WorkflowStep",
-              "name": "Create Threat Bulletin",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "''",
-                "params": {
-                  "title": "",
-                  "description": "",
-                  "status": "",
-                  "tlp": "",
-                  "server_collections": null,
-                  "tags": null,
-                  "attachments": null
-                },
-                "version": "2.0.0",
-                "connector": "cyware-ctix",
-                "operation": "create_threat_bulletin",
-                "operationTitle": "Create Threat Bulletin",
-                "step_variables": {}
-              },
-              "left": "188",
-              "top": "120",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "e7423d39-7d82-4499-a03a-bb73de9cdeb2",
-              "label": null,
-              "isExecuted": false,
-              "name": "Start-> Create Threat Bulletin",
-              "sourceStep": "/api/3/workflow_steps/c77ce3a9-3be3-42f8-ac54-8e9f4dfe91a6",
-              "targetStep": "/api/3/workflow_steps/ea9a6fe8-dff1-473a-a243-fc670fdde5b7"
-            }
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "uuid": "f3375b20-7ff8-46c7-9da8-36fac07a11f3",
-          "collection": "/api/3/workflow_collections/675d21d5-03ec-4286-a40a-f7a02fcedab3",
-          "triggerLimit": null,
-          "description": "Updates the threat bulletin.",
-          "name": "Update Threat Bulletin",
-          "tag": "#Cyware CTIX",
-          "recordTags": [
-            "Cyware",
-            "cyware-ctix"
-          ],
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "parameters": [],
-          "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/003a159b-50e9-4955-9db2-1e9313714a54",
-          "steps": [
-            {
-              "uuid": "003a159b-50e9-4955-9db2-1e9313714a54",
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "route": "849b9697-0b40-423f-8e65-b26e54b31f88",
-                "title": "Cyware CTIX: Update Threat Bulletin",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "singleRecordExecution": false,
-                "noRecordExecution": true,
-                "executeButtonText": "Execute"
-              },
-              "left": "20",
-              "top": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
-            },
-            {
-              "uuid": "09faea18-403e-4b95-aaf7-e98ff31e23cb",
-              "@type": "WorkflowStep",
-              "name": "Update Threat Bulletin",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "''",
-                "params": {
-                  "threat_bulletin_id": "",
-                  "title": "",
-                  "description": null,
-                  "status": "",
-                  "tlp": null,
-                  "server_collections": null,
-                  "tags": null
-                },
-                "version": "2.0.0",
-                "connector": "cyware-ctix",
-                "operation": "update_threat_bulletin",
-                "operationTitle": "Update Threat Bulletin",
-                "step_variables": {}
-              },
-              "left": "188",
-              "top": "120",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "056a67a5-4b71-4e34-b480-0a6c8b25de2d",
-              "label": null,
-              "isExecuted": false,
-              "name": "Start-> Update Threat Bulletin",
-              "sourceStep": "/api/3/workflow_steps/003a159b-50e9-4955-9db2-1e9313714a54",
-              "targetStep": "/api/3/workflow_steps/09faea18-403e-4b95-aaf7-e98ff31e23cb"
-            }
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "uuid": "849ac877-2ef3-4191-9bae-f163b8fb60b3",
-          "collection": "/api/3/workflow_collections/675d21d5-03ec-4286-a40a-f7a02fcedab3",
-          "triggerLimit": null,
-          "description": "Retrieves a list of rules from the platform.",
-          "name": "List Rules",
-          "tag": "#Cyware CTIX",
-          "recordTags": [
-            "Cyware",
-            "cyware-ctix"
-          ],
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "parameters": [],
-          "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/584a7d59-dd7f-41da-a1f9-3fae89dd299e",
-          "steps": [
-            {
-              "uuid": "584a7d59-dd7f-41da-a1f9-3fae89dd299e",
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "route": "762f6fe7-5905-4c5d-b09d-bdd309455cc6",
-                "title": "Cyware CTIX: List Rules",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "singleRecordExecution": false,
-                "noRecordExecution": true,
-                "executeButtonText": "Execute"
-              },
-              "left": "20",
-              "top": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
-            },
-            {
-              "uuid": "9e1904de-a0f0-4f18-a985-a762c3572769",
-              "@type": "WorkflowStep",
-              "name": "List Rules",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "''",
-                "params": {
-                  "page": 1,
-                  "pageSize": 10,
-                  "source": "",
-                  "createdByID": "",
-                  "status": "",
-                  "lastActiveTo": null,
-                  "lastActiveFrom": null,
-                  "createdFrom": null,
-                  "createdTo": "",
-                  "isManualRun": false
-                },
-                "version": "2.0.0",
-                "connector": "cyware-ctix",
-                "operation": "list_rules",
-                "operationTitle": "List Rules",
-                "step_variables": {}
-              },
-              "left": "188",
-              "top": "120",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "11a5e686-c872-4070-ac68-4244707c77fb",
-              "label": null,
-              "isExecuted": false,
-              "name": "Start-> List Rules",
-              "sourceStep": "/api/3/workflow_steps/584a7d59-dd7f-41da-a1f9-3fae89dd299e",
-              "targetStep": "/api/3/workflow_steps/9e1904de-a0f0-4f18-a985-a762c3572769"
-            }
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "uuid": "bfa159d7-1070-44ab-8b86-b54eb8796ba7",
-          "collection": "/api/3/workflow_collections/675d21d5-03ec-4286-a40a-f7a02fcedab3",
-          "triggerLimit": null,
-          "description": "Runs a rule asynchronously on the existing threat data created in the specified time interval.",
-          "name": "Run Rule",
-          "tag": "#Cyware CTIX",
-          "recordTags": [
-            "Cyware",
-            "cyware-ctix"
-          ],
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "parameters": [],
-          "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/cb5fcc9f-ee02-4778-bbdb-dd7df17d5024",
-          "steps": [
-            {
-              "uuid": "cb5fcc9f-ee02-4778-bbdb-dd7df17d5024",
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "route": "312fba2a-6147-418d-9416-12f079612ebf",
-                "title": "Cyware CTIX: Run Rule",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "singleRecordExecution": false,
-                "noRecordExecution": true,
-                "executeButtonText": "Execute"
-              },
-              "left": "20",
-              "top": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
-            },
-            {
-              "uuid": "b8ace1ed-878e-43e9-8d56-dce9a6a3741d",
-              "@type": "WorkflowStep",
-              "name": "Run Rule",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "''",
-                "params": {
-                  "rule": "",
-                  "startTime": null,
-                  "endTime": null
-                },
-                "version": "2.0.0",
-                "connector": "cyware-ctix",
-                "operation": "run_rule",
-                "operationTitle": "Run Rule",
-                "step_variables": {}
-              },
-              "left": "188",
-              "top": "120",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "b077788b-16fa-4616-9222-02d82f34571b",
-              "label": null,
-              "isExecuted": false,
-              "name": "Start-> Run Rule",
-              "sourceStep": "/api/3/workflow_steps/cb5fcc9f-ee02-4778-bbdb-dd7df17d5024",
-              "targetStep": "/api/3/workflow_steps/b8ace1ed-878e-43e9-8d56-dce9a6a3741d"
-            }
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "uuid": "be15a88d-f046-42c8-a3e3-c18b393a4e2e",
-          "collection": "/api/3/workflow_collections/675d21d5-03ec-4286-a40a-f7a02fcedab3",
-          "triggerLimit": null,
-          "description": "Returns the list of enrichment tools configured in Intel Exchange.",
-          "name": "Get Enrichment Tool List",
-          "tag": "#Cyware CTIX",
-          "recordTags": [
-            "Cyware",
-            "cyware-ctix"
-          ],
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "parameters": [],
-          "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/70f960fb-c5a4-4c1f-89f8-b2bbda3fe0ae",
-          "steps": [
-            {
-              "uuid": "70f960fb-c5a4-4c1f-89f8-b2bbda3fe0ae",
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "route": "97d61075-ec15-4a93-a266-a01cf3882560",
-                "title": "Cyware CTIX: Get Enrichment Tool List",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "singleRecordExecution": false,
-                "noRecordExecution": true,
-                "executeButtonText": "Execute"
-              },
-              "left": "20",
-              "top": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
-            },
-            {
-              "uuid": "00ae2c38-63d7-4877-b2e1-f5f0396e3c03",
-              "@type": "WorkflowStep",
-              "name": "Get Enrichment Tool List",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "''",
-                "params": {
-                  "action_name": null,
-                  "component": "",
-                  "full_list": "true"
-                },
-                "version": "2.0.0",
-                "connector": "cyware-ctix",
-                "operation": "enrichment_tools",
-                "operationTitle": "Get Enrichment Tool List",
-                "step_variables": {}
-              },
-              "left": "188",
-              "top": "120",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "407f70d8-9b81-42f1-b33a-dfe33c622aa9",
-              "label": null,
-              "isExecuted": false,
-              "name": "Start-> Get Enrichment Tool List",
-              "sourceStep": "/api/3/workflow_steps/70f960fb-c5a4-4c1f-89f8-b2bbda3fe0ae",
-              "targetStep": "/api/3/workflow_steps/00ae2c38-63d7-4877-b2e1-f5f0396e3c03"
-            }
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "uuid": "1144dfef-ea89-4019-8b42-e9f69c4998a8",
-          "collection": "/api/3/workflow_collections/675d21d5-03ec-4286-a40a-f7a02fcedab3",
-          "triggerLimit": null,
-          "description": "Retrieves the enrichment data for the given object and tool ID.",
-          "name": "Get Enrichment Object Details",
-          "tag": "#Cyware CTIX",
-          "recordTags": [
-            "Cyware",
-            "cyware-ctix"
-          ],
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "parameters": [],
-          "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/58131ae5-efdc-4af8-ae64-8fe1ad418271",
-          "steps": [
-            {
-              "uuid": "58131ae5-efdc-4af8-ae64-8fe1ad418271",
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "route": "29154edb-7d57-4c5c-9ce8-3da1d2ab0602",
-                "title": "Cyware CTIX: Get Enrichment Object Details",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "singleRecordExecution": false,
-                "noRecordExecution": true,
-                "executeButtonText": "Execute"
-              },
-              "left": "20",
-              "top": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
-            },
-            {
-              "uuid": "fb0a3c58-87f8-4743-a181-066f75d3d628",
-              "@type": "WorkflowStep",
-              "name": "Get Enrichment Object Details",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "''",
-                "params": {
-                  "object_type": "",
-                  "objectID": "",
-                  "toolID": ""
-                },
-                "version": "2.0.0",
-                "connector": "cyware-ctix",
-                "operation": "get_enrichment_object_details",
-                "operationTitle": "Get Enrichment Object Details",
-                "step_variables": {}
-              },
-              "left": "188",
-              "top": "120",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "ac5ba736-be1d-494a-9c05-e03a0aa487ec",
-              "label": null,
-              "isExecuted": false,
-              "name": "Start-> Get Enrichment Object Details",
-              "sourceStep": "/api/3/workflow_steps/58131ae5-efdc-4af8-ae64-8fe1ad418271",
-              "targetStep": "/api/3/workflow_steps/fb0a3c58-87f8-4743-a181-066f75d3d628"
-            }
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "uuid": "294a2d19-515a-4f01-b276-0b57a3837341",
-          "collection": "/api/3/workflow_collections/675d21d5-03ec-4286-a40a-f7a02fcedab3",
-          "triggerLimit": null,
-          "description": "Returns the enriched data of a threat data object using enrichment tools.",
-          "name": "Get Enriched Threat Data",
-          "tag": "#Cyware CTIX",
-          "recordTags": [
-            "Cyware",
-            "cyware-ctix"
-          ],
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "parameters": [],
-          "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/d979691a-38e1-4c97-9367-d3a15678b336",
-          "steps": [
-            {
-              "uuid": "d979691a-38e1-4c97-9367-d3a15678b336",
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "route": "d3a5138d-208c-4105-9f89-0962cd79619b",
-                "title": "Cyware CTIX: Get Enriched Threat Data",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "singleRecordExecution": false,
-                "noRecordExecution": true,
-                "executeButtonText": "Execute"
-              },
-              "left": "20",
-              "top": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
-            },
-            {
-              "uuid": "da28f12e-0553-4073-9398-ff3b54b66cd7",
-              "@type": "WorkflowStep",
-              "name": "Get Enriched Threat Data",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "''",
-                "params": {
-                  "app_slug": "",
-                  "value": "",
-                  "action_slug": "",
-                  "objectID": "",
-                  "object_type": ""
-                },
-                "version": "2.0.0",
-                "connector": "cyware-ctix",
-                "operation": "get_enriched_threat_data",
-                "operationTitle": "Get Enriched Threat Data",
-                "step_variables": {}
-              },
-              "left": "188",
-              "top": "120",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "10cccc6b-df48-4c0d-9708-0a9db9bcc490",
-              "label": null,
-              "isExecuted": false,
-              "name": "Start-> Get Enriched Threat Data",
-              "sourceStep": "/api/3/workflow_steps/d979691a-38e1-4c97-9367-d3a15678b336",
-              "targetStep": "/api/3/workflow_steps/da28f12e-0553-4073-9398-ff3b54b66cd7"
-            }
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "uuid": "fe203c27-23c9-47e1-97f8-13ac6a62717d",
-          "collection": "/api/3/workflow_collections/675d21d5-03ec-4286-a40a-f7a02fcedab3",
-          "triggerLimit": null,
-          "description": "Adds a note to a threat data object",
-          "name": "Add Note to Threat Data Object",
-          "tag": "#Cyware CTIX",
-          "recordTags": [
-            "Cyware",
-            "cyware-ctix"
-          ],
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "parameters": [],
-          "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/230226d3-1f88-4b3b-a9f4-2e483ee24dc1",
-          "steps": [
-            {
-              "uuid": "230226d3-1f88-4b3b-a9f4-2e483ee24dc1",
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "route": "8f149fc7-77d6-48be-a447-d798efb94f9d",
-                "title": "Cyware CTIX: Add Note to Threat Data Object",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "singleRecordExecution": false,
-                "noRecordExecution": true,
-                "executeButtonText": "Execute"
-              },
-              "left": "20",
-              "top": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
-            },
-            {
-              "uuid": "7a3f4b48-503e-47ac-80a2-4f77f39098c9",
-              "@type": "WorkflowStep",
-              "name": "Add Note to Threat Data Object",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "''",
-                "params": {
-                  "object_id": "",
-                  "text": null,
-                  "type": "",
-                  "meta_data": null,
-                  "is_json": false
-                },
-                "version": "2.0.0",
-                "connector": "cyware-ctix",
-                "operation": "add_note_to_threat_data_object",
-                "operationTitle": "Add Note to Threat Data Object",
-                "step_variables": {}
-              },
-              "left": "188",
-              "top": "120",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "2e026b0b-4e05-47c9-8bb9-3393cd9f68f8",
-              "label": null,
-              "isExecuted": false,
-              "name": "Start-> Add Note to Threat Data Object",
-              "sourceStep": "/api/3/workflow_steps/230226d3-1f88-4b3b-a9f4-2e483ee24dc1",
-              "targetStep": "/api/3/workflow_steps/7a3f4b48-503e-47ac-80a2-4f77f39098c9"
-            }
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "uuid": "3ae5a416-301d-4f16-991a-0c995eda3834",
-          "collection": "/api/3/workflow_collections/675d21d5-03ec-4286-a40a-f7a02fcedab3",
-          "triggerLimit": null,
-          "description": "Creates a tag in the CTIX platform",
-          "name": "Create Tag",
-          "tag": "#Cyware CTIX",
-          "recordTags": [
-            "Cyware",
-            "cyware-ctix"
-          ],
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "parameters": [],
-          "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/2ef8a1a6-6003-4a8d-88b4-1d7750e2f54c",
-          "steps": [
-            {
-              "uuid": "2ef8a1a6-6003-4a8d-88b4-1d7750e2f54c",
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "route": "abfecd99-8498-4ca8-8b24-397218b0ed4f",
-                "title": "Cyware CTIX: Create Tag",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "singleRecordExecution": false,
-                "noRecordExecution": true,
-                "executeButtonText": "Execute"
-              },
-              "left": "20",
-              "top": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
-            },
-            {
-              "uuid": "65ae4074-0539-4fde-b8e7-ff0b6c11b161",
-              "@type": "WorkflowStep",
-              "name": "Create Tag",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "''",
-                "params": {
-                  "name": "",
-                  "colour_code": null
-                },
-                "version": "2.0.0",
-                "connector": "cyware-ctix",
-                "operation": "create_tag",
-                "operationTitle": "Create Tag",
-                "step_variables": {}
-              },
-              "left": "188",
-              "top": "120",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "f672d2b9-f080-4991-892d-f30168e9c2b4",
-              "label": null,
-              "isExecuted": false,
-              "name": "Start-> Create Tag",
-              "sourceStep": "/api/3/workflow_steps/2ef8a1a6-6003-4a8d-88b4-1d7750e2f54c",
-              "targetStep": "/api/3/workflow_steps/65ae4074-0539-4fde-b8e7-ff0b6c11b161"
-            }
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "uuid": "b3021d4d-a33e-404c-bfa7-9f64908be8b4",
-          "collection": "/api/3/workflow_collections/675d21d5-03ec-4286-a40a-f7a02fcedab3",
-          "triggerLimit": null,
-          "description": "Deletes a tag by the tag ID.",
-          "name": "Delete Tag",
-          "tag": "#Cyware CTIX",
-          "recordTags": [
-            "Cyware",
-            "cyware-ctix"
-          ],
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "parameters": [],
-          "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/36daa82f-1517-465e-b7cf-213e4cdbe372",
-          "steps": [
-            {
-              "uuid": "36daa82f-1517-465e-b7cf-213e4cdbe372",
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "route": "efd85552-d140-4fb6-9d6a-7e30352d606b",
-                "title": "Cyware CTIX: Delete Tag",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "singleRecordExecution": false,
-                "noRecordExecution": true,
-                "executeButtonText": "Execute"
-              },
-              "left": "20",
-              "top": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
-            },
-            {
-              "uuid": "8a541a16-51a0-47b1-8191-9913930f6f92",
-              "@type": "WorkflowStep",
-              "name": "Delete Tag",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "''",
-                "params": {
-                  "tag_id": ""
-                },
-                "version": "2.0.0",
-                "connector": "cyware-ctix",
-                "operation": "delete_tag",
-                "operationTitle": "Delete Tag",
-                "step_variables": {}
-              },
-              "left": "188",
-              "top": "120",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "e2bb8d12-9114-4138-a55f-6ed1bdee4c9f",
-              "label": null,
-              "isExecuted": false,
-              "name": "Start-> Delete Tag",
-              "sourceStep": "/api/3/workflow_steps/36daa82f-1517-465e-b7cf-213e4cdbe372",
-              "targetStep": "/api/3/workflow_steps/8a541a16-51a0-47b1-8191-9913930f6f92"
-            }
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "uuid": "eee7d6e9-9bc1-4bfb-86ca-9176df1f5e50",
-          "collection": "/api/3/workflow_collections/675d21d5-03ec-4286-a40a-f7a02fcedab3",
-          "triggerLimit": null,
-          "description": "Returns a list of allowed indicators from the CTIX platform.",
-          "name": "List Allowed Indicators",
-          "tag": "#Cyware CTIX",
-          "recordTags": [
-            "Cyware",
-            "cyware-ctix"
-          ],
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "parameters": [],
-          "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/ae2d7cff-7a2c-4516-aa1a-7af2deed0dba",
-          "steps": [
-            {
-              "uuid": "ae2d7cff-7a2c-4516-aa1a-7af2deed0dba",
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "route": "084c8dd6-ffc5-4d2f-b288-05684e68c5ea",
-                "title": "Cyware CTIX: List Allowed Indicators",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "singleRecordExecution": false,
-                "noRecordExecution": true,
-                "executeButtonText": "Execute"
-              },
-              "left": "20",
-              "top": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
-            },
-            {
-              "uuid": "f78b6c15-b9c6-48ba-b702-f5cfe6bbe8fa",
-              "@type": "WorkflowStep",
-              "name": "List Allowed Indicators",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "''",
-                "params": {
-                  "type": "",
-                  "page": 1,
-                  "page_size": 10,
-                  "created_by_id": "",
-                  "modified_by_id": "",
-                  "created_from": "",
-                  "created_to": "",
-                  "last_active_from": "",
-                  "last_active_to": "",
-                  "sort": "-created"
-                },
-                "version": "2.0.0",
-                "connector": "cyware-ctix",
-                "operation": "list_allowed_indicators",
-                "operationTitle": "List Allowed Indicators",
-                "step_variables": {}
-              },
-              "left": "188",
-              "top": "120",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "c18fa87b-da39-4a20-85f3-9f504fefc6a5",
-              "label": null,
-              "isExecuted": false,
-              "name": "Start-> List Allowed Indicators",
-              "sourceStep": "/api/3/workflow_steps/ae2d7cff-7a2c-4516-aa1a-7af2deed0dba",
-              "targetStep": "/api/3/workflow_steps/f78b6c15-b9c6-48ba-b702-f5cfe6bbe8fa"
-            }
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "uuid": "9af96fbf-140c-4908-a67f-9af1b0607cb8",
-          "collection": "/api/3/workflow_collections/675d21d5-03ec-4286-a40a-f7a02fcedab3",
-          "triggerLimit": null,
-          "description": "Deletes a particular allowed indicator entry from the dashboard.",
-          "name": "Delete Allowed Indicator",
-          "tag": "#Cyware CTIX",
-          "recordTags": [
-            "Cyware",
-            "cyware-ctix"
-          ],
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "parameters": [],
-          "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/978984bb-a783-4073-a806-16bac646f3af",
-          "steps": [
-            {
-              "uuid": "978984bb-a783-4073-a806-16bac646f3af",
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "route": "bc186358-2464-45cb-87c9-fc015a2a2470",
-                "title": "Cyware CTIX: Delete Allowed Indicator",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "singleRecordExecution": false,
-                "noRecordExecution": true,
-                "executeButtonText": "Execute"
-              },
-              "left": "20",
-              "top": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
-            },
-            {
-              "uuid": "bc4af83e-7715-40b8-ac25-09c8a65f84fe",
-              "@type": "WorkflowStep",
-              "name": "Delete Allowed Indicator",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "''",
-                "params": {
-                  "indicator_id": ""
-                },
-                "version": "2.0.0",
-                "connector": "cyware-ctix",
-                "operation": "delete_allowed_indicator",
-                "operationTitle": "Delete Allowed Indicator",
-                "step_variables": {}
-              },
-              "left": "188",
-              "top": "120",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "642acc85-8317-4538-85b5-45345abd1b3b",
-              "label": null,
-              "isExecuted": false,
-              "name": "Start-> Delete Allowed Indicator",
-              "sourceStep": "/api/3/workflow_steps/978984bb-a783-4073-a806-16bac646f3af",
-              "targetStep": "/api/3/workflow_steps/bc4af83e-7715-40b8-ac25-09c8a65f84fe"
-            }
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "uuid": "d220ed76-a724-4f06-8d14-9a7354cbb6e7",
-          "collection": "/api/3/workflow_collections/675d21d5-03ec-4286-a40a-f7a02fcedab3",
-          "triggerLimit": null,
-          "description": "Retrieves a list of reports from the CTIX application.",
           "name": "List Reports",
+          "aliasName": null,
           "tag": "#Cyware CTIX",
-          "recordTags": [
-            "Cyware",
-            "cyware-ctix"
-          ],
+          "description": "Retrieves a list of reports from the CTIX application.",
           "isActive": false,
           "debug": false,
           "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
           "parameters": [],
           "synchronous": false,
+          "lastModifyDate": null,
+          "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
+          "versions": [],
           "triggerStep": "/api/3/workflow_steps/3522148c-eea1-4db4-acd2-b52e852609b4",
           "steps": [
             {
-              "uuid": "3522148c-eea1-4db4-acd2-b52e852609b4",
+              "@type": "WorkflowStep",
+              "name": "List Reports",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "''",
+                "params": {
+                  "page": 1,
+                  "type": "basic",
+                  "page_size": 10,
+                  "created_by": "",
+                  "created_to": "",
+                  "modified_by": "",
+                  "modified_to": null,
+                  "repeat_type": "none",
+                  "shared_type": "global",
+                  "created_from": "",
+                  "modified_from": "",
+                  "date_last_run_to": "",
+                  "date_last_run_from": ""
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "list_reports",
+                "operationTitle": "List Reports",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "120",
+              "left": "188",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "288f7f88-b405-459d-9ddc-528db60a1cb4"
+            },
+            {
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
-              "status": null,
               "arguments": {
                 "route": "7972f834-e2d9-4821-af4c-17a9f9324cc8",
                 "title": "Cyware CTIX: List Reports",
@@ -3426,89 +3565,301 @@
                     "records": "{{vars.input.records[0]}}"
                   }
                 },
-                "singleRecordExecution": false,
+                "executeButtonText": "Execute",
                 "noRecordExecution": true,
-                "executeButtonText": "Execute"
+                "singleRecordExecution": false
               },
-              "left": "20",
-              "top": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
-            },
-            {
-              "uuid": "288f7f88-b405-459d-9ddc-528db60a1cb4",
-              "@type": "WorkflowStep",
-              "name": "List Reports",
-              "description": null,
               "status": null,
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "3522148c-eea1-4db4-acd2-b52e852609b4"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start-> List Reports",
+              "targetStep": "/api/3/workflow_steps/288f7f88-b405-459d-9ddc-528db60a1cb4",
+              "sourceStep": "/api/3/workflow_steps/3522148c-eea1-4db4-acd2-b52e852609b4",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "3a56a75b-3dd3-454b-9692-237368367587"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "d220ed76-a724-4f06-8d14-9a7354cbb6e7",
+          "id": 3239,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "Cyware",
+            "cyware-ctix"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Get Threat Data Object Additional Details",
+          "aliasName": null,
+          "tag": "#Cyware CTIX",
+          "description": "Retrieves additional information of a threat data object, such as, kill chain phases and published collections.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": null,
+          "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/57d582bc-4760-4f98-b8ce-071c28ff453a",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Get Threat Data Object Additional Details",
+              "description": null,
               "arguments": {
                 "name": "Cyware CTIX",
                 "config": "''",
                 "params": {
-                  "type": "basic",
+                  "object_id": "",
+                  "object_type": ""
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "threat_data_object_advanced_details",
+                "operationTitle": "Get Threat Data Object Additional Details",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "120",
+              "left": "188",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "9efacd7a-ac12-495a-8f84-0084ed90d85e"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "835ba3db-60a6-4ac2-b60d-f3e093cd564a",
+                "title": "Cyware CTIX: Get Threat Data Object Additional Details",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "57d582bc-4760-4f98-b8ce-071c28ff453a"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start-> Get Threat Data Object Additional Details",
+              "targetStep": "/api/3/workflow_steps/9efacd7a-ac12-495a-8f84-0084ed90d85e",
+              "sourceStep": "/api/3/workflow_steps/57d582bc-4760-4f98-b8ce-071c28ff453a",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "b493f880-a934-421b-8c06-036a5d6f2c86"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "d2d91d00-298d-4f44-8cb1-a09d02f1c8ed",
+          "id": 3225,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "Cyware",
+            "cyware-ctix"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Create Threat Bulletin",
+          "aliasName": null,
+          "tag": "#Cyware CTIX",
+          "description": "Creates a threat bulletin.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": null,
+          "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/c77ce3a9-3be3-42f8-ac54-8e9f4dfe91a6",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Create Threat Bulletin",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "''",
+                "params": {
+                  "tlp": "",
+                  "tags": null,
+                  "title": "",
+                  "status": "",
+                  "attachments": null,
+                  "description": "",
+                  "server_collections": null
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "create_threat_bulletin",
+                "operationTitle": "Create Threat Bulletin",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "120",
+              "left": "188",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "ea9a6fe8-dff1-473a-a243-fc670fdde5b7"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "6c86f4d7-4d1d-4291-a07e-135eaee871f0",
+                "title": "Cyware CTIX: Create Threat Bulletin",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "c77ce3a9-3be3-42f8-ac54-8e9f4dfe91a6"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start-> Create Threat Bulletin",
+              "targetStep": "/api/3/workflow_steps/ea9a6fe8-dff1-473a-a243-fc670fdde5b7",
+              "sourceStep": "/api/3/workflow_steps/c77ce3a9-3be3-42f8-ac54-8e9f4dfe91a6",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "e7423d39-7d82-4499-a03a-bb73de9cdeb2"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "d5003a4e-e685-4f21-b747-646129700c9a",
+          "id": 3227,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "Cyware",
+            "cyware-ctix"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "List Allowed Indicators",
+          "aliasName": null,
+          "tag": "#Cyware CTIX",
+          "description": "Returns a list of allowed indicators from the CTIX platform.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": null,
+          "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/ae2d7cff-7a2c-4516-aa1a-7af2deed0dba",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "List Allowed Indicators",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "''",
+                "params": {
                   "page": 1,
+                  "sort": "-created",
+                  "type": "",
                   "page_size": 10,
-                  "repeat_type": "none",
-                  "shared_type": "global",
-                  "created_by": "",
-                  "modified_by": "",
                   "created_to": "",
                   "created_from": "",
-                  "modified_from": "",
-                  "modified_to": null,
-                  "date_last_run_from": "",
-                  "date_last_run_to": ""
+                  "created_by_id": "",
+                  "last_active_to": "",
+                  "modified_by_id": "",
+                  "last_active_from": ""
                 },
                 "version": "2.0.0",
                 "connector": "cyware-ctix",
-                "operation": "list_reports",
-                "operationTitle": "List Reports",
-                "step_variables": {}
+                "operation": "list_allowed_indicators",
+                "operationTitle": "List Allowed Indicators",
+                "step_variables": []
               },
-              "left": "188",
+              "status": null,
               "top": "120",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
-            }
-          ],
-          "routes": [
+              "left": "188",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "f78b6c15-b9c6-48ba-b702-f5cfe6bbe8fa"
+            },
             {
-              "@type": "WorkflowRoute",
-              "uuid": "3a56a75b-3dd3-454b-9692-237368367587",
-              "label": null,
-              "isExecuted": false,
-              "name": "Start-> List Reports",
-              "sourceStep": "/api/3/workflow_steps/3522148c-eea1-4db4-acd2-b52e852609b4",
-              "targetStep": "/api/3/workflow_steps/288f7f88-b405-459d-9ddc-528db60a1cb4"
-            }
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "uuid": "a64fb8b5-48d2-4b34-b145-d7967d348d66",
-          "collection": "/api/3/workflow_collections/675d21d5-03ec-4286-a40a-f7a02fcedab3",
-          "triggerLimit": null,
-          "description": "Creates a basic (standard) report in CTIX.",
-          "name": "Create Report",
-          "tag": "#Cyware CTIX",
-          "recordTags": [
-            "Cyware",
-            "cyware-ctix"
-          ],
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "parameters": [],
-          "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/96978eeb-ddef-4e2e-9c31-32ea46f70a39",
-          "steps": [
-            {
-              "uuid": "96978eeb-ddef-4e2e-9c31-32ea46f70a39",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
-              "status": null,
               "arguments": {
-                "route": "586b1d8e-f76b-478e-af14-7e6ca158e152",
-                "title": "Cyware CTIX: Create Report",
+                "route": "084c8dd6-ffc5-4d2f-b288-05684e68c5ea",
+                "title": "Cyware CTIX: List Allowed Indicators",
                 "resources": [
                   "alerts"
                 ],
@@ -3518,87 +3869,70 @@
                     "records": "{{vars.input.records[0]}}"
                   }
                 },
-                "singleRecordExecution": false,
+                "executeButtonText": "Execute",
                 "noRecordExecution": true,
-                "executeButtonText": "Execute"
+                "singleRecordExecution": false
               },
-              "left": "20",
-              "top": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
-            },
-            {
-              "uuid": "4a77c083-a64c-4a5d-8b84-34143f037dd0",
-              "@type": "WorkflowStep",
-              "name": "Create Report",
-              "description": null,
               "status": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "''",
-                "params": {
-                  "name": "",
-                  "type": "basic",
-                  "basic_report_type": "custom",
-                  "shared_type": null,
-                  "saved_search": null,
-                  "schedule": null,
-                  "file_types": null,
-                  "columns": null,
-                  "internal_recipients": null,
-                  "query_key": "ctix_created",
-                  "external_recipients": null
-                },
-                "version": "2.0.0",
-                "connector": "cyware-ctix",
-                "operation": "create_report",
-                "operationTitle": "Create Report",
-                "step_variables": {}
-              },
-              "left": "188",
-              "top": "120",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "ae2d7cff-7a2c-4516-aa1a-7af2deed0dba"
             }
           ],
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "8c7bb499-5a9e-4838-a785-f59a357f32cf",
+              "name": "Start-> List Allowed Indicators",
+              "targetStep": "/api/3/workflow_steps/f78b6c15-b9c6-48ba-b702-f5cfe6bbe8fa",
+              "sourceStep": "/api/3/workflow_steps/ae2d7cff-7a2c-4516-aa1a-7af2deed0dba",
               "label": null,
               "isExecuted": false,
-              "name": "Start-> Create Report",
-              "sourceStep": "/api/3/workflow_steps/96978eeb-ddef-4e2e-9c31-32ea46f70a39",
-              "targetStep": "/api/3/workflow_steps/4a77c083-a64c-4a5d-8b84-34143f037dd0"
+              "group": null,
+              "uuid": "c18fa87b-da39-4a20-85f3-9f504fefc6a5"
             }
+          ],
+          "groups": [],
+          "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "eee7d6e9-9bc1-4bfb-86ca-9176df1f5e50",
+          "id": 3237,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "Cyware",
+            "cyware-ctix"
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "31ebf40d-51c5-42f6-8842-8a29e400554c",
-          "collection": "/api/3/workflow_collections/675d21d5-03ec-4286-a40a-f7a02fcedab3",
           "triggerLimit": null,
-          "description": "Runs a report and sends the file to the recipients",
-          "name": "Run Report",
+          "name": "Update Threat Bulletin",
+          "aliasName": null,
           "tag": "#Cyware CTIX",
-          "recordTags": [
-            "Cyware",
-            "cyware-ctix"
-          ],
+          "description": "Updates the threat bulletin.",
           "isActive": false,
           "debug": false,
           "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/6484dad8-6d99-452b-be98-da868bdf92b5",
+          "lastModifyDate": null,
+          "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/003a159b-50e9-4955-9db2-1e9313714a54",
           "steps": [
             {
-              "uuid": "6484dad8-6d99-452b-be98-da868bdf92b5",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
-              "status": null,
               "arguments": {
-                "route": "c8fc8006-a853-4dc4-84b6-230e9300f4a6",
-                "title": "Cyware CTIX: Run Report",
+                "route": "849b9697-0b40-423f-8e65-b26e54b31f88",
+                "title": "Cyware CTIX: Update Threat Bulletin",
                 "resources": [
                   "alerts"
                 ],
@@ -3608,83 +3942,124 @@
                     "records": "{{vars.input.records[0]}}"
                   }
                 },
-                "singleRecordExecution": false,
+                "executeButtonText": "Execute",
                 "noRecordExecution": true,
-                "executeButtonText": "Execute"
+                "singleRecordExecution": false
               },
-              "left": "20",
+              "status": null,
               "top": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "003a159b-50e9-4955-9db2-1e9313714a54"
             },
             {
-              "uuid": "70195abc-dffc-42f9-a697-f3dc53012c20",
               "@type": "WorkflowStep",
-              "name": "Run Report",
+              "name": "Update Threat Bulletin",
               "description": null,
-              "status": null,
               "arguments": {
                 "name": "Cyware CTIX",
                 "config": "''",
                 "params": {
-                  "report_id": "",
-                  "type": "basic",
-                  "start_time": "",
-                  "end_time": "",
-                  "file_types": "",
-                  "internal_recipients": {},
-                  "external_recipients": {}
+                  "tlp": null,
+                  "tags": null,
+                  "title": "",
+                  "status": "",
+                  "description": null,
+                  "server_collections": null,
+                  "threat_bulletin_id": ""
                 },
                 "version": "2.0.0",
                 "connector": "cyware-ctix",
-                "operation": "run_report",
-                "operationTitle": "Run Report",
-                "step_variables": {}
+                "operation": "update_threat_bulletin",
+                "operationTitle": "Update Threat Bulletin",
+                "step_variables": []
               },
-              "left": "188",
+              "status": null,
               "top": "120",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
+              "left": "188",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "09faea18-403e-4b95-aaf7-e98ff31e23cb"
             }
           ],
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "36ec5d54-5997-4eb2-a110-ecf7d77e1082",
+              "name": "Start-> Update Threat Bulletin",
+              "targetStep": "/api/3/workflow_steps/09faea18-403e-4b95-aaf7-e98ff31e23cb",
+              "sourceStep": "/api/3/workflow_steps/003a159b-50e9-4955-9db2-1e9313714a54",
               "label": null,
               "isExecuted": false,
-              "name": "Start-> Run Report",
-              "sourceStep": "/api/3/workflow_steps/6484dad8-6d99-452b-be98-da868bdf92b5",
-              "targetStep": "/api/3/workflow_steps/70195abc-dffc-42f9-a697-f3dc53012c20"
+              "group": null,
+              "uuid": "056a67a5-4b71-4e34-b480-0a6c8b25de2d"
             }
+          ],
+          "groups": [],
+          "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "f3375b20-7ff8-46c7-9da8-36fac07a11f3",
+          "id": 3228,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "Cyware",
+            "cyware-ctix"
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "89c9002d-57c6-42f0-be8b-73477d03ac9d",
-          "collection": "/api/3/workflow_collections/675d21d5-03ec-4286-a40a-f7a02fcedab3",
           "triggerLimit": null,
-          "description": "Create a custom attribute in the platform.",
-          "name": "Create Custom Attribute",
+          "name": "Bulk Deprecate/Undeprecate Objects",
+          "aliasName": null,
           "tag": "#Cyware CTIX",
-          "recordTags": [
-            "Cyware",
-            "cyware-ctix"
-          ],
+          "description": "Deprecate or undeprecate multiple threat data objects with one API request.",
           "isActive": false,
           "debug": false,
           "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/f3e07787-018b-4303-8b7f-64a56683ec7c",
+          "lastModifyDate": null,
+          "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/39a52948-2877-431c-91a9-552ad03a9f0a",
           "steps": [
             {
-              "uuid": "f3e07787-018b-4303-8b7f-64a56683ec7c",
+              "@type": "WorkflowStep",
+              "name": "Bulk Deprecate/Undeprecate Objects",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "''",
+                "params": {
+                  "object_ids": "",
+                  "action_type": "deprecate",
+                  "object_type": ""
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "bulk_deprecate_undeprecate_objects",
+                "operationTitle": "Bulk Deprecate/Undeprecate Objects",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "120",
+              "left": "188",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "5cbd830c-d609-4aac-b617-d373d9ddedeb"
+            },
+            {
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
-              "status": null,
               "arguments": {
-                "route": "1fbf3177-7d1b-47c7-b8de-4b897efe8a77",
-                "title": "Cyware CTIX: Create Custom Attribute",
+                "route": "075779ac-5a74-4bee-9bc6-a67ec7f1aad0",
+                "title": "Cyware CTIX: Bulk Deprecate/Undeprecate Objects",
                 "resources": [
                   "alerts"
                 ],
@@ -3694,53 +4069,143 @@
                     "records": "{{vars.input.records[0]}}"
                   }
                 },
-                "singleRecordExecution": false,
+                "executeButtonText": "Execute",
                 "noRecordExecution": true,
-                "executeButtonText": "Execute"
+                "singleRecordExecution": false
               },
-              "left": "20",
-              "top": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
-            },
-            {
-              "uuid": "3c3262e5-65d9-453c-b22a-a849c4797567",
-              "@type": "WorkflowStep",
-              "name": "Create Custom Attribute",
-              "description": null,
               "status": null,
-              "arguments": {
-                "name": "Cyware CTIX",
-                "config": "''",
-                "params": {
-                  "name": "",
-                  "description": "",
-                  "type": null,
-                  "choices": null,
-                  "is_actionable": false,
-                  "status": "1",
-                  "sdo_objects": null
-                },
-                "version": "2.0.0",
-                "connector": "cyware-ctix",
-                "operation": "create_custom_attribute",
-                "operationTitle": "Create Custom Attribute",
-                "step_variables": {}
-              },
-              "left": "188",
-              "top": "120",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "39a52948-2877-431c-91a9-552ad03a9f0a"
             }
           ],
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "cd5eade3-1a74-4c34-b476-79f888ce572b",
+              "name": "Start-> Bulk Deprecate/Undeprecate Objects",
+              "targetStep": "/api/3/workflow_steps/5cbd830c-d609-4aac-b617-d373d9ddedeb",
+              "sourceStep": "/api/3/workflow_steps/39a52948-2877-431c-91a9-552ad03a9f0a",
               "label": null,
               "isExecuted": false,
-              "name": "Start-> Create Custom Attribute",
-              "sourceStep": "/api/3/workflow_steps/f3e07787-018b-4303-8b7f-64a56683ec7c",
-              "targetStep": "/api/3/workflow_steps/3c3262e5-65d9-453c-b22a-a849c4797567"
+              "group": null,
+              "uuid": "968ef713-86b1-4df2-889a-d06c02999b50"
             }
+          ],
+          "groups": [],
+          "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "f68c4531-84a3-497e-8183-4caba6b7d89f",
+          "id": 3220,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "Cyware",
+            "cyware-ctix"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Add Note to Threat Data Object",
+          "aliasName": null,
+          "tag": "#Cyware CTIX",
+          "description": "Adds a note to a threat data object",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": null,
+          "collection": "/api/3/workflow_collections/95ed288e-1618-47c0-a78f-dc8dc2f3bf2d",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/230226d3-1f88-4b3b-a9f4-2e483ee24dc1",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Add Note to Threat Data Object",
+              "description": null,
+              "arguments": {
+                "name": "Cyware CTIX",
+                "config": "''",
+                "params": {
+                  "text": null,
+                  "type": "",
+                  "is_json": false,
+                  "meta_data": null,
+                  "object_id": ""
+                },
+                "version": "2.0.0",
+                "connector": "cyware-ctix",
+                "operation": "add_note_to_threat_data_object",
+                "operationTitle": "Add Note to Threat Data Object",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "120",
+              "left": "188",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "7a3f4b48-503e-47ac-80a2-4f77f39098c9"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "8f149fc7-77d6-48be-a447-d798efb94f9d",
+                "title": "Cyware CTIX: Add Note to Threat Data Object",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "230226d3-1f88-4b3b-a9f4-2e483ee24dc1"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start-> Add Note to Threat Data Object",
+              "targetStep": "/api/3/workflow_steps/7a3f4b48-503e-47ac-80a2-4f77f39098c9",
+              "sourceStep": "/api/3/workflow_steps/230226d3-1f88-4b3b-a9f4-2e483ee24dc1",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "2e026b0b-4e05-47c9-8bb9-3393cd9f68f8"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "fe203c27-23c9-47e1-97f8-13ac6a62717d",
+          "id": 3234,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "Cyware",
+            "cyware-ctix"
           ]
         }
       ]
@@ -3749,8 +4214,8 @@
   "macros": [
     {
       "name": "Demo_mode",
-      "value": "False",
-      "default_value": "False"
+      "value": "false",
+      "default_value": "false"
     }
   ],
   "exported_tags": [


### PR DESCRIPTION
### Descriptions:
This PR was made to update the sample and enrichment playbooks. The check health endpoint has also been updated to the ping endpoint. For the previously existing sample and enrichment playbooks, they have been updated to use the v2.0.0 connector step where they were showing v1.1.0 previously. The collection name has been changed to 2.0.0.

#### Fix:
- Changed the Check Health step to use /ping endpoint
- Updated already existing playbooks to use v2.0.0 connector step and changed the collection name to reflect this

#### Affected Actions:
- [ ] All
- [X] Check Health
- [ ] Other Actions

#### QA Impact:
- [ ] `full`
- [ ] Test what is prescribed in the Mantis Ticket
- [ ] Regression Impacts
- [ ] Regression Area X
- [ ] Ensure that platform dependencies remain unaffected

#### UTCs:
- [ ] Connector installation verified
- [ ] Connector logo verified
- [ ] Check health verified
- [ ] Docs link verified
- [ ] Actions and Playbooks list verified
- [ ] Playbook tags verified
- [ ] All playbooks are in info mode verified
- [ ] All playbooks are in inactive mode verified
- [ ] Ingestion playbooks are verified
- [ ] Verified platform dependencies remain unaffected

#### Pytest Test Cases: (If applicable)
- [ ] Attach the test report
